### PR TITLE
Filter out unsupported linker arg `--disable-auto-image-base` for Windows gnu targets

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -6,6 +6,10 @@ on:
     tags: [ 'v*' ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   macos:
     runs-on: macos-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os_str_bytes"


### PR DESCRIPTION
See #96 