### PR TITLE
Replace `armv8-a` with `apple_a14` for `aarch64-apple-darwin`

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -137,15 +137,19 @@ impl Zig {
                     return None;
                 }
             }
-            // Ignore `-march` option for arm* targets, we use `generic` + cpu features instead
-            if is_arm && arg.starts_with("-march=") {
-                return None;
-            }
-            if is_i386 && arg.starts_with("-march=") {
-                return None;
-            }
-            if is_riscv64 && arg.starts_with("-march=") {
-                return Some("-march=generic_rv64".to_string());
+            if arg.starts_with("-march=") {
+                // Ignore `-march` option for arm* targets, we use `generic` + cpu features instead
+                if is_arm || is_i386 {
+                    return None;
+                } else if is_riscv64 {
+                    return Some("-march=generic_rv64".to_string());
+                } else if arg.starts_with("-march=armv8-a")
+                    && target
+                        .map(|x| x.starts_with("aarch64-macos"))
+                        .unwrap_or_default()
+                {
+                    return Some(arg.replace("armv8-a", "apple_a14"));
+                }
             }
             Some(arg.to_string())
         };


### PR DESCRIPTION
`aarch64-unknown-linux-gnu` has the same problem, but I'm unable to workaround it like this (https://github.com/ziglang/zig/issues/14467).

```
   Compiling sha2-asm v0.6.2
The following warnings were emitted during compilation:

warning: src/sha256_aarch64.S:75:2: error: instruction requires: sha2
warning:  sha256su0 v8.4s, v9.4s
warning:  ^
warning: src/sha256_aarch64.S:78:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:79:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:80:2: error: instruction requires: sha2
warning:  sha256su1 v8.4s, v10.4s, v11.4s
warning:  ^
warning: src/sha256_aarch64.S:83:2: error: instruction requires: sha2
warning:  sha256su0 v9.4s, v10.4s
warning:  ^
warning: src/sha256_aarch64.S:86:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:87:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:88:2: error: instruction requires: sha2
warning:  sha256su1 v9.4s, v11.4s, v8.4s
warning:  ^
warning: src/sha256_aarch64.S:91:2: error: instruction requires: sha2
warning:  sha256su0 v10.4s, v11.4s
warning:  ^
warning: src/sha256_aarch64.S:94:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:95:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:96:2: error: instruction requires: sha2
warning:  sha256su1 v10.4s, v8.4s, v9.4s
warning:  ^
warning: src/sha256_aarch64.S:99:2: error: instruction requires: sha2
warning:  sha256su0 v11.4s, v8.4s
warning:  ^
warning: src/sha256_aarch64.S:102:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:103:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:104:2: error: instruction requires: sha2
warning:  sha256su1 v11.4s, v9.4s, v10.4s
warning:  ^
warning: src/sha256_aarch64.S:107:2: error: instruction requires: sha2
warning:  sha256su0 v8.4s, v9.4s
warning:  ^
warning: src/sha256_aarch64.S:110:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:111:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:112:2: error: instruction requires: sha2
warning:  sha256su1 v8.4s, v10.4s, v11.4s
warning:  ^
warning: src/sha256_aarch64.S:115:2: error: instruction requires: sha2
warning:  sha256su0 v9.4s, v10.4s
warning:  ^
warning: src/sha256_aarch64.S:118:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:119:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:120:2: error: instruction requires: sha2
warning:  sha256su1 v9.4s, v11.4s, v8.4s
warning:  ^
warning: src/sha256_aarch64.S:123:2: error: instruction requires: sha2
warning:  sha256su0 v10.4s, v11.4s
warning:  ^
warning: src/sha256_aarch64.S:126:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:127:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:128:2: error: instruction requires: sha2
warning:  sha256su1 v10.4s, v8.4s, v9.4s
warning:  ^
warning: src/sha256_aarch64.S:131:2: error: instruction requires: sha2
warning:  sha256su0 v11.4s, v8.4s
warning:  ^
warning: src/sha256_aarch64.S:134:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:135:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:136:2: error: instruction requires: sha2
warning:  sha256su1 v11.4s, v9.4s, v10.4s
warning:  ^
warning: src/sha256_aarch64.S:139:2: error: instruction requires: sha2
warning:  sha256su0 v8.4s, v9.4s
warning:  ^
warning: src/sha256_aarch64.S:142:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:143:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:144:2: error: instruction requires: sha2
warning:  sha256su1 v8.4s, v10.4s, v11.4s
warning:  ^
warning: src/sha256_aarch64.S:147:2: error: instruction requires: sha2
warning:  sha256su0 v9.4s, v10.4s
warning:  ^
warning: src/sha256_aarch64.S:150:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:151:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:152:2: error: instruction requires: sha2
warning:  sha256su1 v9.4s, v11.4s, v8.4s
warning:  ^
warning: src/sha256_aarch64.S:155:2: error: instruction requires: sha2
warning:  sha256su0 v10.4s, v11.4s
warning:  ^
warning: src/sha256_aarch64.S:158:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:159:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:160:2: error: instruction requires: sha2
warning:  sha256su1 v10.4s, v8.4s, v9.4s
warning:  ^
warning: src/sha256_aarch64.S:163:2: error: instruction requires: sha2
warning:  sha256su0 v11.4s, v8.4s
warning:  ^
warning: src/sha256_aarch64.S:166:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:167:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:168:2: error: instruction requires: sha2
warning:  sha256su1 v11.4s, v9.4s, v10.4s
warning:  ^
warning: src/sha256_aarch64.S:173:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:174:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:179:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:180:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:185:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:186:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v6.4s
warning:  ^
warning: src/sha256_aarch64.S:190:2: error: instruction requires: sha2
warning:  sha256h q2, q3, v7.4s
warning:  ^
warning: src/sha256_aarch64.S:191:2: error: instruction requires: sha2
warning:  sha256h2 q3, q4, v7.4s
warning:  ^

error: failed to run custom build command for `sha2-asm v0.6.2`

Caused by:
  process didn't exit successfully: `/Users/messense/Projects/cargo-zigbuild/tests/libhello/target/debug/build/sha2-asm-5ffca58902476491/build-script-build` (exit status: 1)
  --- stdout
  TARGET = Some("aarch64-unknown-linux-gnu")
  OPT_LEVEL = Some("0")
  HOST = Some("aarch64-apple-darwin")
  cargo:rerun-if-env-changed=CC_aarch64-unknown-linux-gnu
  CC_aarch64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_aarch64_unknown_linux_gnu
  CC_aarch64_unknown_linux_gnu = Some("/Users/messense/Library/Caches/cargo-zigbuild/0.16.8/zigcc-aarch64-unknown-linux-gnu.sh")
  cargo:rerun-if-env-changed=CFLAGS_aarch64-unknown-linux-gnu
  CFLAGS_aarch64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_aarch64_unknown_linux_gnu
  CFLAGS_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("neon")
  running: "/Users/messense/Library/Caches/cargo-zigbuild/0.16.8/zigcc-aarch64-unknown-linux-gnu.sh" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-Wall" "-Wextra" "-march=armv8-a+crypto" "-c" "-o" "/Users/messense/Projects/cargo-zigbuild/tests/libhello/target/aarch64-unknown-linux-gnu/debug/build/sha2-asm-9a8c2face348c109/out/src/sha256_aarch64.o" "-c" "src/sha256_aarch64.S"
  cargo:warning=src/sha256_aarch64.S:75:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v8.4s, v9.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:78:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:79:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:80:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v8.4s, v10.4s, v11.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:83:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v9.4s, v10.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:86:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:87:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:88:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v9.4s, v11.4s, v8.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:91:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v10.4s, v11.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:94:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:95:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:96:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v10.4s, v8.4s, v9.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:99:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v11.4s, v8.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:102:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:103:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:104:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v11.4s, v9.4s, v10.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:107:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v8.4s, v9.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:110:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:111:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:112:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v8.4s, v10.4s, v11.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:115:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v9.4s, v10.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:118:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:119:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:120:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v9.4s, v11.4s, v8.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:123:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v10.4s, v11.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:126:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:127:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:128:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v10.4s, v8.4s, v9.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:131:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v11.4s, v8.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:134:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:135:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:136:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v11.4s, v9.4s, v10.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:139:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v8.4s, v9.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:142:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:143:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:144:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v8.4s, v10.4s, v11.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:147:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v9.4s, v10.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:150:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:151:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:152:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v9.4s, v11.4s, v8.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:155:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v10.4s, v11.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:158:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:159:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:160:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v10.4s, v8.4s, v9.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:163:2: error: instruction requires: sha2
  cargo:warning= sha256su0 v11.4s, v8.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:166:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:167:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:168:2: error: instruction requires: sha2
  cargo:warning= sha256su1 v11.4s, v9.4s, v10.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:173:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:174:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:179:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:180:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:185:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:186:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v6.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:190:2: error: instruction requires: sha2
  cargo:warning= sha256h q2, q3, v7.4s
  cargo:warning= ^
  cargo:warning=src/sha256_aarch64.S:191:2: error: instruction requires: sha2
  cargo:warning= sha256h2 q3, q4, v7.4s
  cargo:warning= ^
  exit status: 1

  --- stderr


  error occurred: Command "/Users/messense/Library/Caches/cargo-zigbuild/0.16.8/zigcc-aarch64-unknown-linux-gnu.sh" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-Wall" "-Wextra" "-march=armv8-a+crypto" "-c" "-o" "/Users/messense/Projects/cargo-zigbuild/tests/libhello/target/aarch64-unknown-linux-gnu/debug/build/sha2-asm-9a8c2face348c109/out/src/sha256_aarch64.o" "-c" "src/sha256_aarch64.S" with args "zigcc-aarch64-unknown-linux-gnu.sh" did not execute successfully (status code exit status: 1).


```

Closes #130 