### PR TITLE
Fix the build for zig 0.11.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
         os: [ubuntu-latest, macos-13, windows-latest]
         toolchain: [1.63.0, stable, nightly]
         # Ideally we should also test against 0.9.0, but it is too unusable to test from CI
-        zig: [0.10.1, master]
+        zig: [0.10.1, 0.11.0, master]
         exclude:
           # Only test MSRV with zig stable version
           - toolchain: 1.63.0


### PR DESCRIPTION
1. use linker `rust-lld` for linux-musl targets
2. replace `-Wl,-Bdynamic` with `-Wl,-search_paths_first` to workaround another linker issue for windows-gnu targets