### PR TITLE
Add `libcharset.1.tbd` for Apple targets

### DIFF
--- a/src/macos/libcharset.1.tbd
+++ b/src/macos/libcharset.1.tbd
@@ -1,0 +1,25 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos, x86_64-maccatalyst, arm64-macos, arm64-maccatalyst, 
+                   arm64e-macos, arm64e-maccatalyst ]
+uuids:
+  - target:          x86_64-macos
+    value:           5B967C5A-B6AC-322F-B731-4D653B8462B8
+  - target:          x86_64-maccatalyst
+    value:           5B967C5A-B6AC-322F-B731-4D653B8462B8
+  - target:          arm64-macos
+    value:           00000000-0000-0000-0000-000000000000
+  - target:          arm64-maccatalyst
+    value:           00000000-0000-0000-0000-000000000000
+  - target:          arm64e-macos
+    value:           A83762DF-A611-3148-9926-C0874266E926
+  - target:          arm64e-maccatalyst
+    value:           A83762DF-A611-3148-9926-C0874266E926
+install-name:    '/usr/lib/libcharset.1.dylib'
+current-version: 2
+compatibility-version: 2
+exports:
+  - targets:         [ arm64e-macos, x86_64-macos, x86_64-maccatalyst, arm64e-maccatalyst, 
+                       arm64-macos, arm64-maccatalyst ]
+    symbols:         [ _libcharset_set_relocation_prefix, _locale_charset ]
+...

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,2 +1,4 @@
 /// libiconv.tbd
 pub static LIBICONV_TBD: &str = include_str!("libiconv.tbd");
+/// libcharset.tbd
+pub static LIBCHARSET_TBD: &str = include_str!("libcharset.1.tbd");

--- a/tests/hello-rustls/Cargo.lock
+++ b/tests/hello-rustls/Cargo.lock
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",


### PR DESCRIPTION
```
  = note: error: missing dynamic library dependency: '/usr/lib/libcharset.1.dylib'
              note: tried /usr/lib/libcharset.1.tbd
              note: tried /usr/lib/libcharset.1.dylib
```