### PR TITLE
A slightly better approach to add weak symbols to the build for musl 1.2.4

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -18,3 +18,10 @@ pub static FCNTL_H: &str = r#"
 __asm__(".symver fcntl64, fcntl@GLIBC_2.2.5");
 #endif
 "#;
+
+pub static MUSL_WEAK_SYMBOLS_MAPPING_SCRIPT: &str = r#"
+PROVIDE (open64 = open);
+PROVIDE (stat64 = stat);
+PROVIDE (fstat64 = fstat);
+PROVIDE (lseek64 = lseek);
+"#;


### PR DESCRIPTION
- Add rust version check since rust 1.72 fixes the weak symbol issues for musl
- Use a linker script to add missing symbols during linking for zig >= 0.11 and rust < 1.72 (it should be better than using `rust-lld` since we can use the old logic to adjust parameters passed to zig )