### PR TITLE
Fix Windows CMake build error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.toolchain != '1.63.0'
         shell: bash
         run: |
-          set -e
+          set -euo pipefail
           git clone --recurse-submodules https://github.com/gyscos/zstd-rs.git tests/zstd-rs
           cargo run zigbuild --manifest-path tests/zstd-rs/Cargo.toml --features bindgen --target aarch64-unknown-linux-gnu
           cargo run zigbuild --manifest-path tests/zstd-rs/Cargo.toml --features bindgen --target x86_64-pc-windows-gnu
@@ -97,7 +97,7 @@ jobs:
         env:
           SDK: MacOSX11.3.sdk
         run: |
-          set -e
+          set -euo pipefail
           curl -sqL https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/$SDK.tar.xz | tar -Jx
           export SDKROOT=$PWD/$SDK
 
@@ -127,7 +127,9 @@ jobs:
             ldd -r -v ./target/x86_64-unknown-linux-gnu/debug/cargo-zigbuild
             ./target/x86_64-unknown-linux-gnu/debug/cargo-zigbuild --help
       - name: Linux - Test glibc build
+        shell: bash
         run: |
+          set -euo pipefail
           cargo run zigbuild --target aarch64-unknown-linux-gnu
           cargo run zigbuild --target aarch64-unknown-linux-gnu.2.17
 
@@ -142,6 +144,7 @@ jobs:
       - name: Linux - Test glibc run/test
         if: matrix.os == 'ubuntu-latest'
         run: |
+          set -euo pipefail
           # Install qemu for `cargo-zigbuild run` support
           sudo apt-get update
           sudo apt-get install -y qemu-user qemu-user-static gcc-aarch64-linux-gnu binfmt-support
@@ -160,7 +163,9 @@ jobs:
           cargo run zigbuild --target aarch64-unknown-linux-musl
           cargo run zigbuild --target aarch64-unknown-linux-musl --manifest-path tests/hello-rustls/Cargo.toml
       - name: Windows - Test gnu build
+        shell: bash
         run: |
+          set -euo pipefail
           cargo run zigbuild --target x86_64-pc-windows-gnu
           cargo run zigbuild --target x86_64-pc-windows-gnu --manifest-path tests/hello-windows/Cargo.toml
           cargo run zigbuild --target i686-pc-windows-gnu
@@ -171,7 +176,9 @@ jobs:
           cargo run zigbuild --target aarch64-unknown-linux-gnu --manifest-path tests/hello-rustls/Cargo.toml --features curl
       - name: Windows - Test run
         if: matrix.os == 'windows-latest'
+        shell: bash
         run: |
+          set -euo pipefail
           ./target/x86_64-pc-windows-gnu/debug/cargo-zigbuild.exe zigbuild --help
           ./tests/hello-windows/target/x86_64-pc-windows-gnu/debug/hello-windows.exe
 

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -866,9 +866,10 @@ impl Zig {
             r#"
 set(CMAKE_SYSTEM_NAME {system_name})
 set(CMAKE_SYSTEM_PROCESSOR {system_processor})
-set(CMAKE_C_COMPILER {cc})
-set(CMAKE_CXX_COMPILER {cxx})
-set(CMAKE_RANLIB {ranlib})"#,
+set(CMAKE_C_COMPILER {cc} CACHE FILEPATH "")
+set(CMAKE_CXX_COMPILER {cxx} CACHE FILEPATH "")
+set(CMAKE_LINKER {cc} CACHE FILEPATH "")
+set(CMAKE_RANLIB {ranlib} CACHE FILEPATH "")"#,
             system_name = system_name,
             system_processor = system_processor,
             cc = zig_wrapper.cc.to_slash_lossy(),
@@ -877,7 +878,7 @@ set(CMAKE_RANLIB {ranlib})"#,
         );
         if enable_zig_ar {
             content.push_str(&format!(
-                "\nset(CMAKE_AR {})\n",
+                "\nset(CMAKE_AR {} CACHE FILEPATH \"\")\n",
                 zig_wrapper.ar.to_slash_lossy()
             ));
         }


### PR DESCRIPTION
Closes #174 

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # TL;DR
> This pull request modifies the CI.yml and zig.rs files to improve error handling and to set the CMake variables as cache variables.
> 
> # What changed
> In the CI.yml file, the `set -e` command was replaced with `set -euo pipefail` to ensure that the script stops on the first error it encounters and does not ignore any errors. This change was made in multiple places in the file.
> 
> In the zig.rs file, the CMake variables `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, `CMAKE_LINKER`, and `CMAKE_RANLIB` are now set as cache variables. This is done by appending `CACHE FILEPATH ""` to the `set` command. This change ensures that the variables are stored in the CMake cache and can be reused in subsequent CMake runs.
> 
> # How to test
> To test these changes, you can run the CI workflow. If the workflow completes successfully, it means that the changes are working as expected. You can also manually run the commands in the CI.yml file and check if they stop execution upon encountering an error.
> 
> To test the changes in the zig.rs file, you can run a CMake build and check if the CMake variables are correctly set as cache variables. You can do this by inspecting the CMakeCache.txt file or by using the `cmake -LH` command.
> 
> # Why make this change
> The changes in the CI.yml file improve error handling by ensuring that the script stops execution when it encounters an error. This can help in identifying and fixing issues more quickly.
> 
> The changes in the zig.rs file make the CMake build process more efficient by storing the CMake variables in the cache. This can speed up subsequent CMake runs as the variables do not need to be recalculated.
</details>