### PR TITLE
Add `cargo-zigbuild doc` support

### DIFF
--- a/src/bin/cargo-zigbuild.rs
+++ b/src/bin/cargo-zigbuild.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 
-use cargo_zigbuild::{Build, Check, Clippy, Install, Run, Rustc, Test, Zig};
+use cargo_zigbuild::{Build, Check, Clippy, Doc, Install, Run, Rustc, Test, Zig};
 use clap::Parser;
 
 #[allow(clippy::large_enum_variant)]
@@ -21,6 +21,8 @@ pub enum Opt {
     Clippy(Clippy),
     #[command(name = "check", aliases = &["c"])]
     Check(Check),
+    #[command(name = "doc")]
+    Doc(Doc),
     #[command(name = "install")]
     Install(Install),
     #[command(name = "rustc")]
@@ -58,6 +60,10 @@ fn main() -> anyhow::Result<()> {
             Opt::Check(mut check) => {
                 check.enable_zig_ar = true;
                 check.execute()?
+            }
+            Opt::Doc(mut doc) => {
+                doc.enable_zig_ar = true;
+                doc.execute()?
             }
             Opt::Install(mut install) => {
                 install.enable_zig_ar = true;

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -1,0 +1,87 @@
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+use std::process::{self, Command};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::Zig;
+
+#[derive(Clone, Debug, Default, Parser)]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help doc` for more detailed information."
+)]
+pub struct Doc {
+    #[command(flatten)]
+    pub cargo: cargo_options::Doc,
+
+    /// Disable zig linker
+    #[arg(skip)]
+    pub disable_zig_linker: bool,
+
+    /// Enable zig ar
+    #[arg(skip)]
+    pub enable_zig_ar: bool,
+}
+
+impl Doc {
+    /// Create a new doc from manifest path
+    #[allow(clippy::field_reassign_with_default)]
+    pub fn new(manifest_path: Option<PathBuf>) -> Self {
+        let mut build = Self::default();
+        build.manifest_path = manifest_path;
+        build
+    }
+
+    /// Execute `cargo doc` command
+    pub fn execute(&self) -> Result<()> {
+        let mut run = self.build_command()?;
+
+        let mut child = run.spawn().context("Failed to run cargo doc")?;
+        let status = child.wait().expect("Failed to wait on cargo doc process");
+        if !status.success() {
+            process::exit(status.code().unwrap_or(1));
+        }
+        Ok(())
+    }
+
+    /// Generate cargo subcommand
+    pub fn build_command(&self) -> Result<Command> {
+        let mut build = self.cargo.command();
+        if !self.disable_zig_linker {
+            Zig::apply_command_env(
+                self.manifest_path.as_deref(),
+                self.release,
+                &self.cargo.common,
+                &mut build,
+                self.enable_zig_ar,
+            )?;
+        }
+
+        Ok(build)
+    }
+}
+
+impl Deref for Doc {
+    type Target = cargo_options::Doc;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cargo
+    }
+}
+
+impl DerefMut for Doc {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cargo
+    }
+}
+
+impl From<cargo_options::Doc> for Doc {
+    fn from(cargo: cargo_options::Doc) -> Self {
+        Self {
+            cargo,
+            ..Default::default()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod build;
 mod check;
 mod clippy;
+mod doc;
 mod install;
 pub mod linux;
 pub mod macos;
@@ -12,6 +13,7 @@ pub mod zig;
 pub use crate::clippy::Clippy;
 pub use build::Build;
 pub use check::Check;
+pub use doc::Doc;
 pub use install::Install;
 pub use run::Run;
 pub use rustc::Rustc;


### PR DESCRIPTION
Closes: https://github.com/rust-cross/cargo-zigbuild/issues/233

Note: this depends on https://github.com/messense/cargo-options/pull/10 being merged, released. Then Cargo.{toml,lock} here needs to be updated to use that version.  Testing was done locally using `[patch.crates-io]` and was successful.