### PR TITLE
chore: upgrade target-lexicon to 0.12.15 for openharmony

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "terminal_size"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ semver = "1.0.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 shlex = "1"
-target-lexicon = { version = "0.12.5", features = ["std"] }
+target-lexicon = { version = "0.12.15", features = ["std"] }
 which = "6.0.0"
 
 [features]


### PR DESCRIPTION
Related: https://github.com/bytecodealliance/target-lexicon/pull/104