### PR TITLE
Use new target wasm32-wasip1 that replaces wasm32-wasm

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -1229,6 +1229,9 @@ pub fn prepare_zig_linker(target: &str) -> Result<ZigWrapper> {
         OperatingSystem::Wasi => {
             cc_args.push(format!("-target {arch}-wasi{abi_suffix}"));
         }
+        OperatingSystem::WasiP1 => {
+            cc_args.push(format!("-target {arch}-wasi.0.1.0{abi_suffix}"));
+        }
         OperatingSystem::Unknown => {
             if triple.architecture == Architecture::Wasm32
                 || triple.architecture == Architecture::Wasm64


### PR DESCRIPTION
Early this year, WASI 0.2 has been stabilized, hence the need to differentiate wasi targets (https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html)

However, in Zig land Andrew decided to call this target `wasm32-wasi.0.1.0` (https://github.com/ziglang/zig/issues/19581#issuecomment-2057966056)

This PR makes '--target=wasm32-wasip1` work and removes the warnings when running `--target=wasm32-wasi`

I tried it out with (https://github.com/scristobal/cross-compiling-rust-c-wasm-zig) and it works just fine. 