### PR TITLE
fix _ typo in `CARGO_ZIGBUILD_RUSTC_VERSION`

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -517,7 +517,7 @@ impl Zig {
         let rustc_meta = rustc_version::version_meta()?;
         Self::add_env_if_missing(
             cmd,
-            "CARGOZIG_BUILD_RUSTC_VERSION",
+            "CARGO_ZIGBUILD_RUSTC_VERSION",
             rustc_meta.semver.to_string(),
         );
         let host_target = &rustc_meta.host;


### PR DESCRIPTION
https://github.com/rust-cross/cargo-zigbuild/commit/02165f1e5be3a3354ef9f819182cbcce9c2412e1#diff-49b1f98d9d763bc0e0db9c28ba3dc79ca7413959f017924bc333f7a086d16189R520
post-rename, variables had `_` in different places
