### PR TITLE
chore: Add tips for troubleshooting glibc version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ on macOS, Windows and Linux you can also install zig from PyPI via `pip3 install
 
 ### Specify glibc version
 
-`cargo zigbuild` supports passing glibc version in `--target` option, for example,
-to compile for glibc 2.17 with the `aarch64-unknown-linux-gnu` target:
+By default `--target` for `*-gnu` will have Zig implicitly build for a default version of glibc that varies based on the release of Zig ([v12 to v14 releases default to glibc 2.28](https://github.com/ziglang/zig/blob/0.14.1/lib/std/Target.zig#L473)).
+
+To build for a specific minimum glibc version, add that version as a suffix to the `--target` value. For example, to compile with `--target aarch64-unknown-linux-gnu` for glibc 2.17:
 
 ```bash
 cargo zigbuild --target aarch64-unknown-linux-gnu.2.17
@@ -58,6 +59,75 @@ cargo zigbuild --target aarch64-unknown-linux-gnu.2.17
 >   - Meanwhile specifying 2.33 will correctly be detected as incompatible when run on a host with glibc 2.31.
 > - Certain `RUSTFLAGS` like `-C linker` opt-out of using Zig, while `-L path/to/files` will have Zig ignore `-C target-feature=+crt-static`.
 > - `-C target-feature=+crt-static` for statically linking to a glibc version is **not supported** (_upstream `zig cc` lacks support_)
+
+#### Tip - `cargo zigbuild` cannot find headers (`*.h` files) or libraries that exist
+
+You may need to prepend the following ENV to your `cargo zigbuild` command with the following system paths or similar:
+- `CFLAGS='-isystem /usr/include'`
+- `RUSTFLAGS='-L /usr/lib64'`
+
+---
+
+`cargo zigbuild` always uses the `zig cc` option `-nostdinc` which excludes standard header locations like `/usr/include`. This is also a default behaviour for Zig whenever it is configured with a `--target`, which additionally opts out of standard system search paths.
+
+This can lead to a common difference between `cargo build` being successful, while `cargo zigbuild` fails without extra configuration:
+
+```console
+# Cannot find a header file to build:
+fatal error: 'libelf.h' file not found
+
+# Cannot find a shared library to link:
+error: unable to find dynamic system library 'elf' using strategy 'no_fallback'. searched paths
+```
+
+There is a variety of ways to resolve this, but for system paths like `/usr/include` you must be careful to avoid getting the system glibc headers mixed with the glibc headers Zig provides itself, otherwise this will produce errors like from `CPATH=/usr/include`:
+
+```rust
+In file included from /usr/local/lib64/python3.13/site-packages/ziglang/lib/libunwind/src/gcc_personality_v0.c:21:
+In file included from /usr/local/lib64/python3.13/site-packages/ziglang/lib/libunwind/include/unwind.h:18:
+In file included from /usr/include/stdint.h:26:
+In file included from /usr/include/bits/libc-header-start.h:33:
+/usr/include/features.h:516:9: warning: '__GLIBC_MINOR__' macro redefined [-Wmacro-redefined]
+  516 | #define __GLIBC_MINOR__ 41
+      |         ^
+<command line>:2:9: note: previous definition is here
+    2 | #define __GLIBC_MINOR__ 37
+      |
+```
+
+When you have installed system packages that added headers to `/usr/include` that your project needs to build, you will want Zig to fallback to `/usr/include` just for those headers while using it's own for glibc. This can be done with `zig cc -isystem /usr/include`, which for `cargo zigbuild` can be configured through the common ENV `CFLAGS='-isystem /usr/include'`.
+
+For the similar issue with shared libraries, if your packages are installing system libraries at `/usr/lib64` you would normally use `LDFLAGS='-L /usr/lib64'`, but `rustc` and `cargo` do not read this ENV but they must be configured with the search path for crates with a `build.rs` that searches for a library to link dynamically/statically. Instead you will need to use `RUSTFLAGS='-L /usr/lib64'`.
+
+#### Tip - Verify minimum GLIBC version required
+
+Provided you have no stripped the symbols from your binary built, on Linux you can run the following script to scan for glibc versioned symbols and find the highest version (the minimum required to run)
+
+1. Create a file **`/usr/local/bin/get-min-glibc`:**
+
+   ```bash
+   #!/bin/bash
+   
+   FILE_NAME=$1
+   readelf -W --version-info --dyn-syms ${FILE_NAME} \
+     | grep 'Name: GLIBC' \
+     | sed -re 's/.*GLIBC_(.+) Flags.*/\1/g' \
+     | sort -t . -k1,1n -k2,2n \
+     | tail -n 1
+   ```
+
+2. Make the script command executable:
+
+   ```bash
+   chmod +x /usr/local/bin/get-min-glibc
+   ```
+
+3. Run the command with the path to your executable / library to check:
+
+   ```console
+   $ get-min-glibc target/x86_64-unknown-linux-gnu/release/hello-world
+   2.28
+   ```
 
 ### macOS universal2 target
 


### PR DESCRIPTION
Could perhaps do with some revision, but adding this information to the README may help raise some awareness about `cargo build` vs `cargo zigbuild` troubleshooting when `cargo zigbuild` fails to find headers/libs from standard system paths.

Perhaps there is a way to add `-isystem /usr/include` via `RUSTFLAGS` instead of `CFLAGS`, but I think it may be useful as-is since sometimes troubleshooting can involve building a C/C++ dep directly with Zig to compare why something differs with `cargo zigbuild`.