### PR TITLE
(fix) Disable depfile support

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -1022,7 +1022,9 @@ set(CMAKE_SYSTEM_NAME {system_name})
 set(CMAKE_SYSTEM_PROCESSOR {system_processor})
 set(CMAKE_C_COMPILER {cc})
 set(CMAKE_CXX_COMPILER {cxx})
-set(CMAKE_RANLIB {ranlib})"#,
+set(CMAKE_RANLIB {ranlib})
+set(CMAKE_C_LINKER_DEPFILE_SUPPORTED FALSE)
+set(CMAKE_CXX_LINKER_DEPFILE_SUPPORTED FALSE)"#,
             system_name = system_name,
             system_processor = system_processor,
             cc = zig_wrapper.cc.to_slash_lossy(),


### PR DESCRIPTION
cmake fails with:
`error: unsupported linker arg: --dependency-file=...`

`--dependency-file` is currently not supported in zig.
https://github.com/ziglang/zig/issues/22213

This PR disables depfile support in cmake