### PR TITLE
Don't remove temporary empty files from the cache.

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -691,9 +691,7 @@ impl Zig {
                 .arg("-E")
                 .arg(&empty_file_path)
                 .arg("-v")
-                .output();
-            fs::remove_file(&empty_file_path).ok();
-            let output = output?;
+                .output()?;
             // Clang always generates UTF-8 regardless of locale, so this is okay.
             let stderr = String::from_utf8(output.stderr)?;
             if !output.status.success() {


### PR DESCRIPTION
When multiple processes try to build with Cargo-ZigBuild in parallel, the processes compete writing and removing these files, which can cause the builds to fail.

Since these empty files don't seem problematic, the most simple solution is to keep the files in the cache and reuse them for all invocations. That removes the race condition when two builders try to use them in parallel.

An alternative solution would be to create unique names for those files for every invocation. I don't think the added complexity is necessary, but I'd be happy to change the implementation.

@messense can you take a look at this and release a patch version if it works for you? This fixes this issue: https://github.com/cargo-lambda/cargo-lambda/issues/865