### PR TITLE
feat: follow the change zig@0.15

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -1279,7 +1279,7 @@ pub fn prepare_zig_linker(target: &str) -> Result<ZigWrapper> {
             // We need to follow the change but target_lexicon follow the LLVM target(https://github.com/bytecodealliance/target-lexicon/pull/123).
             // So we use string directly.
             if zig_version >= semver::Version::new(0, 15, 0)
-                && arch.as_str() == "arm"
+                && arch.as_str() == "armv7"
                 && target_env == Environment::Ohos
             {
                 zig_target_env = "ohoseabi".to_string();


### PR DESCRIPTION
Zig changed `arm-linux-ohos` to `arm-linux-ohoseabi`, but target-lexicon don't support `ohoseabi`. It just follows the llvm target. https://github.com/bytecodealliance/target-lexicon/pull/123

So we must have some special codes for arm-linux-ohos.

<img width="620" height="316" alt="image" src="https://github.com/user-attachments/assets/abdb7a94-02bd-45b7-8bbb-5366422bc0e9" />

