### PR TITLE
riscv buildplatform support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PREV_ZIGBUILD_IMG=start9/cargo-zigbuild
+ARG PREV_ZIGBUILD_IMG=ghcr.io/rust-cross/cargo-zigbuild
 ARG RUST_VERSION=1.91.1
 ARG BUILDPLATFORM
 


### PR DESCRIPTION
feel free to close this if this is not a direction you're planning to go, but I wanted to get `cargo zigbuild` docker builds working for a riscv64 *host* architecture. in order to make that work, I had to update zig, and I am building cargo-zigbuild using the previous cargo-zigbuild image for the host architecture. 