### PR TITLE
Support zig 0.16.0: add Mac Catalyst and OpenBSD targets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-15, windows-latest]
         toolchain: [1.88.0, stable, nightly]
-        zig: [0.11.0, 0.15.2, master]
+        zig: [0.11.0, 0.16.0, master]
         exclude:
           # Only test MSRV with zig stable version
           - toolchain: 1.88.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,64 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    environment: Docker Hub
+    steps:
+      - uses: actions/checkout@v6
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_USERNAME }}/cargo-zigbuild
+            ghcr.io/${{ github.repository_owner }}/cargo-zigbuild
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/386,linux/arm64
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          repository: ${{ secrets.DOCKER_USERNAME }}/cargo-zigbuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -135,7 +135,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -162,7 +162,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -184,14 +184,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -209,7 +209,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: artifacts-build-global
           path: |
@@ -234,14 +234,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -254,14 +254,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN cargo build --manifest-path /cargo-zigbuild/Cargo.toml --release
 FROM rust:$RUST_VERSION
 
 # Install Zig
-ARG ZIG_VERSION=0.15.2
+ARG ZIG_VERSION=0.16.0
 # Zig 0.14.0+ changed the tarball naming convention: zig-{arch}-{os}-{version} instead of zig-{os}-{arch}-{version}
 # We detect the version and construct the appropriate URL and directory path
 RUN \

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.3"
+cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -146,7 +146,7 @@ impl TargetInfo {
     fn is_macos(&self) -> bool {
         self.target
             .as_ref()
-            .map(|x| x.contains("macos"))
+            .map(|x| x.contains("macos") || x.contains("maccatalyst"))
             .unwrap_or_default()
     }
 
@@ -167,6 +167,7 @@ impl TargetInfo {
                     || x.contains("tvos")
                     || x.contains("watchos")
                     || x.contains("visionos")
+                    || x.contains("maccatalyst")
             })
             .unwrap_or_default()
     }
@@ -309,10 +310,21 @@ impl Zig {
 
         let mut new_cmd_args = Vec::with_capacity(cmd_args.len());
         let mut skip_next_arg = false;
+        let mut seen_target = false;
         for arg in cmd_args {
             if skip_next_arg {
                 skip_next_arg = false;
                 continue;
+            }
+            // Our wrapper script already passes the correct -target;
+            // skip any duplicate -target from rustc to avoid conflicts
+            // (e.g. rustc passes arm64 which zig doesn't recognize for some targets)
+            if arg == "-target" {
+                if seen_target {
+                    skip_next_arg = true;
+                    continue;
+                }
+                seen_target = true;
             }
             let args = if arg.starts_with('@') && arg.ends_with("linker-arguments") {
                 vec![self.process_linker_response_file(
@@ -1758,6 +1770,12 @@ pub fn prepare_zig_linker(
             cc_args.push("-target".to_string());
             cc_args.push(format!("{arch}-wasi.0.1.0{abi_suffix}"));
         }
+        OperatingSystem::IOS(_) if triple.environment == Environment::Macabi => {
+            // Mac Catalyst (aarch64-apple-ios-macabi / x86_64-apple-ios-macabi)
+            // maps to zig's maccatalyst target
+            cc_args.push("-target".to_string());
+            cc_args.push(format!("{arch}-maccatalyst-none{abi_suffix}"));
+        }
         OperatingSystem::Freebsd => {
             let zig_arch = match arch.as_str() {
                 "i686" => {
@@ -1772,6 +1790,10 @@ pub fn prepare_zig_linker(
             };
             cc_args.push("-target".to_string());
             cc_args.push(format!("{zig_arch}-freebsd"));
+        }
+        OperatingSystem::Openbsd => {
+            cc_args.push("-target".to_string());
+            cc_args.push(format!("{arch}-openbsd"));
         }
         OperatingSystem::Unknown => {
             if triple.architecture == Architecture::Wasm32


### PR DESCRIPTION
- Add Mac Catalyst target support (aarch64/x86_64-apple-ios-macabi) mapping to zig's maccatalyst target
- Add OpenBSD target support mapping to zig's openbsd target
- Filter duplicate -target args from rustc to avoid arm64 arch conflicts
- Update CI to test zig 0.16.0 instead of 0.15.2
- Update cargo-dist to 0.31.0 and regenerate release workflow