### PR TITLE
link compiler-rt for windows-gnu on zig >= 0.16

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -351,6 +351,10 @@ impl Zig {
             new_cmd_args.push("-Wl,-z,notext".to_string());
         }
 
+        if target_info.is_windows_gnu() && (zig_version.major, zig_version.minor) >= (0, 16) {
+            new_cmd_args.push("-lcompiler_rt".to_string());
+        }
+
         if self.has_undefined_dynamic_lookup(cmd_args) {
             new_cmd_args.push("-Wl,-undefined=dynamic_lookup".to_string());
         }


### PR DESCRIPTION
Zig 0.16 aligned `-nolibc`/`-nostdlib` with clang: neither implicitly links compiler-rt anymore.

rustc passes `-nolibc` for gnullvm targets, so compiler-rt intrinsics like `__udivti3` now go unresolved at link time.

This commit opts back in with `-lcompiler_rt` (supported by zig >= 0.16).

References:
* https://codeberg.org/ziglang/zig/commit/0e45a449914e0170179301f721bb2025cac363aa
* https://codeberg.org/ziglang/zig/commit/ab1a4b26ec2b90f514059b6e446b83c3881dbe4d

Closes #438