### PR TITLE
fix: filter unsupported AArch64 Cortex-A53 linker arg

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -537,6 +537,8 @@ fn filter_linker_arg(
         }
     } else if arg == "-Wl,--no-undefined-version"
         || arg == "-Wl,-znostart-stop-gc"
+        // See https://github.com/rust-lang/rust/pull/155453
+        || arg == "-Wl,--fix-cortex-a53-843419"
         || arg.starts_with("-Wl,-plugin-opt")
     {
         return FilteredArg::Skip;
@@ -2380,6 +2382,7 @@ mod tests {
         let removed: &[&str] = &[
             "-Wl,--no-undefined-version",
             "-Wl,-znostart-stop-gc",
+            "-Wl,--fix-cortex-a53-843419",
             "-Wl,-plugin-opt=O2",
         ];
         for arg in removed {


### PR DESCRIPTION
Fixes https://github.com/rust-cross/cargo-zigbuild/issues/451.