### PR TITLE
Fix mips rust <--> zig musl target mapping

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -1639,6 +1639,7 @@ pub fn prepare_zig_linker(
     let arch = triple.architecture.to_string();
     let target_env = match (triple.architecture, triple.environment) {
         (Architecture::Mips32(..), Environment::Gnu) => Environment::Gnueabihf,
+        (Architecture::Mips32(..), Environment::Musl) => Environment::Musleabi,
         (Architecture::Powerpc, Environment::Gnu) => Environment::Gnueabihf,
         (_, Environment::GnuLlvm) => Environment::Gnu,
         (_, environment) => environment,


### PR DESCRIPTION
Rust's mips musl target uses the triple `mips-unknown-linux-musl` but zig expects `mips-linux-musleabi`. This adds the mapping for Mips32 targets to use the `Musleabi` environment, similiar to the expecetion for gnu/glibc targets.  Rust's mips musl target is soft float (`+mips32r2,+soft-float`).