### PR TITLE
Raise macOS file descriptor limit before spawning Cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "fat-macho",
  "fs-err",
  "goblin",
+ "libc",
  "path-slash",
  "rustc_version",
  "rustflags",
@@ -380,9 +381,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ shell-words = "1.1.1"
 target-lexicon = { version = "0.13.0", features = ["std"] }
 which = "8.0.0"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2.189"
+
 [features]
 default = ["universal2"]
 universal2 = ["fat-macho"]

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,4 +1,6 @@
 pub mod install_name_tool;
+#[cfg(target_os = "macos")]
+pub(crate) mod rlimit;
 
 /// libiconv.tbd
 pub static LIBICONV_TBD: &str = include_str!("libiconv.tbd");

--- a/src/macos/rlimit.rs
+++ b/src/macos/rlimit.rs
@@ -1,0 +1,73 @@
+use std::io;
+use std::ptr;
+
+fn nofile_limit() -> io::Result<libc::rlimit> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+
+    // SAFETY: `limit` points to valid writable memory for the duration of the call.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(limit)
+}
+
+fn maxfiles_per_process() -> io::Result<libc::rlim_t> {
+    let mut maxfiles: libc::c_int = 0;
+    let mut size = std::mem::size_of_val(&maxfiles);
+
+    // SAFETY: the output pointer and size describe `maxfiles`, and no new value is provided.
+    if unsafe {
+        libc::sysctlbyname(
+            c"kern.maxfilesperproc".as_ptr(),
+            ptr::from_mut(&mut maxfiles).cast(),
+            &mut size,
+            ptr::null_mut(),
+            0,
+        )
+    } != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(maxfiles as libc::rlim_t)
+}
+
+/// Raise the soft file descriptor limit to the maximum allowed by macOS.
+pub(crate) fn raise_nofile_limit() -> io::Result<()> {
+    let mut limit = nofile_limit()?;
+    // The hard limit defaults to unlimited, while the actual ceiling is this sysctl value.
+    let target = maxfiles_per_process()?.min(limit.rlim_max);
+
+    if limit.rlim_cur >= target {
+        return Ok(());
+    }
+
+    limit.rlim_cur = target;
+    // SAFETY: `limit` is initialized and points to valid memory for the duration of the call.
+    if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limit) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{maxfiles_per_process, nofile_limit, raise_nofile_limit};
+
+    #[test]
+    fn raises_nofile_limit_to_system_maximum() {
+        let before = nofile_limit().unwrap();
+        let target = maxfiles_per_process().unwrap().min(before.rlim_max);
+
+        raise_nofile_limit().unwrap();
+
+        let after = nofile_limit().unwrap();
+        assert_eq!(after.rlim_cur, before.rlim_cur.max(target));
+        assert_eq!(after.rlim_max, before.rlim_max);
+    }
+}

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -902,6 +902,14 @@ impl Zig {
         } else {
             &cargo.target
         };
+        #[cfg(target_os = "macos")]
+        if !raw_targets.is_empty()
+            && let Err(err) = crate::macos::rlimit::raise_nofile_limit()
+        {
+            eprintln!(
+                "warning: failed to raise the open file limit: {err}; large builds may fail with ProcessFdQuotaExceeded (try `ulimit -n 65536`)"
+            );
+        }
         let rust_targets = raw_targets
             .iter()
             .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(target))


### PR DESCRIPTION
Fixes #329.

macOS commonly starts processes with a soft `RLIMIT_NOFILE` of 256 while `kern.maxfilesperproc` is much higher. Zig 0.14+ can exhaust that soft limit while opening linker inputs in parallel.

This raises the soft limit once in the parent `cargo-zigbuild` process before it spawns Cargo. Cargo, rustc, linker wrappers, and Zig inherit the raised limit. The value is capped at the lower of the process hard limit and `kern.maxfilesperproc`; the parent shell is unaffected. If the limit cannot be queried or raised, the build continues with an actionable warning.

The platform-specific implementation uses `libc` 0.2.189 and includes a macOS unit test.

### Manual verification

Tested against [vladkens/ghstats](https://github.com/vladkens/ghstats) on macOS.

```console
❯ ulimit -Sn; ulimit -Hn
256
unlimited

❯ cargo zigbuild --target x86_64-unknown-linux-musl --target aarch64-unknown-linux-musl
   Compiling ...
   Compiling ghstats v0.9.0 (/Users/user/Code/pub/ghstats)
error: linking with `.../zigcc-x86_64-unknown-linux-musl-....sh` failed: exit status: 1
  = note: error: failed to open object ...rcgu.o: ProcessFdQuotaExceeded
error: could not compile `ghstats` (bin "ghstats") due to 1 previous error

❯ ~/code/forks/cargo-zigbuild/target/release/cargo-zigbuild zigbuild --target x86_64-unknown-linux-musl --target aarch64-unknown-linux-musl
   Compiling ...
   Compiling ghstats v0.9.0 (/Users/user/Code/pub/ghstats)
    Finished `dev` profile [unoptimized] target(s) in 56.76s
```

Validation:

- `cargo fmt --all -- --check`
- `cargo test --locked --all-features`
- `cargo +1.88.0 test --locked --all-features`
- `cargo check --locked --all-targets --all-features`
- `cargo +1.88.0 check --locked --all-targets --all-features`
- `cargo clippy --all-features` (passes with four pre-existing warnings)
- `codespell` on all changed source files
- `ulimit -Sn 256; cargo-zigbuild zigbuild --target x86_64-unknown-linux-musl --target aarch64-unknown-linux-musl` with Zig 0.16.0 (both targets succeed)