### PR TITLE
fix: dedup -l args for Apple targets to avoid duplicate linked dylibs

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -346,6 +346,10 @@ impl Zig {
             new_cmd_args.extend(args);
         }
 
+        if target_info.is_apple_platform() {
+            new_cmd_args = dedup_apple_link_libs(new_cmd_args);
+        }
+
         if target_info.is_mips32() {
             // See https://github.com/ziglang/zig/issues/4925#issuecomment-1499823425
             new_cmd_args.push("-Wl,-z,notext".to_string());
@@ -488,7 +492,29 @@ fn filter_linker_args(
             }
         }
     }
+    if target_info.is_apple_platform() {
+        result = dedup_apple_link_libs(result);
+    }
     result
+}
+
+/// Deduplicate `-l` arguments for Apple targets, keeping the first occurrence.
+///
+/// ld64 ignores duplicate libraries, but Zig's Mach-O linker (since 0.14) emits
+/// one `LC_LOAD_DYLIB` load command per `-l` flag, and newer macOS dyld refuses
+/// to load binaries with duplicate linked dylibs.
+/// See https://github.com/rust-cross/cargo-zigbuild/issues/457
+fn dedup_apple_link_libs(args: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    args.into_iter()
+        .filter(|arg| {
+            if arg.starts_with("-l") && arg.len() > 2 {
+                seen.insert(arg.clone())
+            } else {
+                true
+            }
+        })
+        .collect()
 }
 
 fn filter_linker_arg(
@@ -2496,6 +2522,36 @@ mod tests {
         let darwin = Some("aarch64-apple-darwin");
         let result = run_filter_one("-Wl,-dylib", darwin, (13, 0));
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_dedup_apple_duplicate_libs() {
+        // See https://github.com/rust-cross/cargo-zigbuild/issues/457
+        let darwin = Some("aarch64-apple-darwin");
+        let result = run_filter(
+            &[
+                "-lobjc",
+                "-framework",
+                "AppKit",
+                "-lobjc",
+                "-liconv",
+                "-lobjc",
+                "main.o",
+            ],
+            darwin,
+            (16, 0),
+        );
+        assert_eq!(
+            result,
+            vec!["-lobjc", "-framework", "AppKit", "-liconv", "main.o"]
+        );
+        // duplicates are kept on non-Apple targets where link order can matter
+        let result = run_filter(
+            &["-lfoo", "-lfoo"],
+            Some("x86_64-unknown-linux-gnu"),
+            (16, 0),
+        );
+        assert_eq!(result, vec!["-lfoo", "-lfoo"]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #457

## Problem

Binaries built with cargo-zigbuild 0.23 crash at launch on newer macOS (26.x) with:

```
Termination Reason: Namespace DYLD, Code 0,
duplicate linked dylib '/usr/lib/libobjc.A.dylib'
```

Three factors stack up:

1. When multiple crates declare the same native library (e.g. two crates each emitting `cargo:rustc-link-lib=objc`), rustc forwards each occurrence to the linker.
2. Zig's self-hosted Mach-O linker (since 0.14) emits one `LC_LOAD_DYLIB` load command per `-l` flag. Apple's ld64 instead warns and ignores duplicates (`ld: warning: ignoring duplicate libraries: '-lobjc'`). The regression between cargo-zigbuild 0.21 and 0.23 is the Docker image's Zig bump from 0.13 to 0.16.
3. Duplicate `LC_LOAD_DYLIB` entries were tolerated by dyld for years, became a warning around macOS 15, and are now a hard launch error on macOS 26.

Interestingly, Zig already dedups `-framework` flags — only `-l` dylibs are affected.

## Fix

Deduplicate repeated `-l<name>` arguments (keeping the first occurrence) for Apple targets, in both the `@…linker-arguments` response-file path and the direct-args path. This matches ld64 semantics. Non-Apple targets are untouched since link order/repetition of static archives can be load-bearing on ELF.

## Verification

Reproduced with a workspace where two dependency crates each emit `cargo:rustc-link-lib=objc`, built with `cargo zigbuild --target aarch64-apple-darwin` against Zig 0.16.0:

- before: `otool -L` shows `/usr/lib/libobjc.A.dylib` twice
- after: once

Added a unit test covering dedup on `aarch64-apple-darwin` (with interleaved `-framework`/object-file args preserved) and duplicate preservation on Linux. `cargo test`, `cargo fmt`, and `cargo clippy` are clean (clippy shows only warnings already present on main).

This is a workaround for a Zig linker divergence from ld64; it may be worth filing upstream as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012W2Vg9xdxKaD8sEE2HiUQb