### PR TITLE
fix: map GCC/clang CPU and feature spellings to zig's for -march/-mcpu/-mtune

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -625,7 +625,11 @@ fn filter_linker_arg(
                     _ => ('+', ext),
                 };
                 mcpu.push(sign);
-                mcpu.push_str(map_aarch64_arch_extension(name));
+                // zig spells multi-word feature names with underscores
+                // (e.g. sve2_aes) and parses `-` as feature subtraction
+                for c in map_aarch64_arch_extension(name).chars() {
+                    mcpu.push(if c == '-' { '_' } else { c });
+                }
             }
             let mut result = vec![mcpu];
             if has_crypto {
@@ -2552,6 +2556,13 @@ mod tests {
                 "-march=armv8.2-a+simd+profile+rng+memtag",
                 "aarch64-unknown-linux-gnu",
                 &["-mcpu=generic+neon+spe+rand+mte"],
+            ),
+            // aarch64: dashed feature names use underscores in zig,
+            // where `-` would mean feature subtraction
+            (
+                "-march=armv9-a+sve2-aes+fp",
+                "aarch64-unknown-linux-gnu",
+                &["-mcpu=generic+sve2_aes+fp_armv8"],
             ),
             // aarch64: `+no<ext>` disables a feature
             (

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -369,6 +369,17 @@ impl Zig {
             new_cmd_args.push("-Wl,-z,notext".to_string());
         }
 
+        // Rust's libstd for strict-align arm targets calls the ARM RTABI
+        // unaligned-access helpers (__aeabi_uread4 etc.), which libgcc
+        // provides but zig's compiler-rt does not; link weak definitions
+        if target_info.is_arm() && !cmd_args.iter().any(|x| x == "-c" || x == "-E" || x == "-S") {
+            let cache_dir = cache_dir();
+            fs::create_dir_all(&cache_dir)?;
+            let shim_path = cache_dir.join("aeabi_unaligned.c");
+            write_file(&shim_path, AEABI_UNALIGNED_C)?;
+            new_cmd_args.push(shim_path.display().to_string());
+        }
+
         if target_info.is_windows_gnu() && (zig_version.major, zig_version.minor) >= (0, 16) {
             new_cmd_args.push("-lcompiler_rt".to_string());
         }
@@ -1647,6 +1658,37 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"#,
         }
     }
 }
+
+/// Weak definitions of the ARM RTABI unaligned-access helpers
+/// (run-time ABI for the ARM architecture, IHI0043, section 4.3.3).
+/// libgcc provides these but LLVM's (and zig's) compiler-rt does not,
+/// and Rust's libstd for strict-align arm targets calls them.
+const AEABI_UNALIGNED_C: &str = r#"
+#ifdef __cplusplus
+extern "C" {
+#endif
+__attribute__((weak)) int __aeabi_uread4(void *address) {
+    int value;
+    __builtin_memcpy(&value, address, 4);
+    return value;
+}
+__attribute__((weak)) int __aeabi_uwrite4(int value, void *address) {
+    __builtin_memcpy(address, &value, 4);
+    return value;
+}
+__attribute__((weak)) long long __aeabi_uread8(void *address) {
+    long long value;
+    __builtin_memcpy(&value, address, 8);
+    return value;
+}
+__attribute__((weak)) long long __aeabi_uwrite8(long long value, void *address) {
+    __builtin_memcpy(address, &value, 8);
+    return value;
+}
+#ifdef __cplusplus
+}
+#endif
+"#;
 
 fn write_file(path: &Path, content: &str) -> Result<(), anyhow::Error> {
     let existing_content = fs::read_to_string(path).unwrap_or_default();

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -134,6 +134,20 @@ impl TargetInfo {
             .unwrap_or_default()
     }
 
+    fn is_powerpc(&self) -> bool {
+        self.target
+            .as_ref()
+            .map(|x| x.starts_with("powerpc"))
+            .unwrap_or_default()
+    }
+
+    fn is_s390x(&self) -> bool {
+        self.target
+            .as_ref()
+            .map(|x| x.starts_with("s390x"))
+            .unwrap_or_default()
+    }
+
     // libc helpers
     fn is_musl(&self) -> bool {
         self.target
@@ -607,36 +621,34 @@ fn filter_linker_arg(
             && (target_info.is_aarch64() || target_info.is_aarch64_be())
         {
             let march_value = arg.strip_prefix("-march=").unwrap();
-            let mut extensions = march_value.split('+');
-            let _arch = extensions.next();
             let base_cpu = if target_info.is_apple_platform() {
                 target_info.apple_cpu()
             } else {
                 "generic"
             };
-            let mut mcpu = format!("-mcpu={base_cpu}");
-            let mut has_crypto = false;
-            for ext in extensions.filter(|e| !e.is_empty() && *e != "none") {
-                has_crypto |= ext == "crypto";
-                // GCC/clang spell disabling an extension `+no<ext>`,
-                // zig's -mcpu spells it `-<feature>`
-                let (sign, name) = match ext.strip_prefix("no") {
-                    Some(name) if !name.is_empty() => ('-', name),
-                    _ => ('+', ext),
-                };
-                mcpu.push(sign);
-                // zig spells multi-word feature names with underscores
-                // (e.g. sve2_aes) and parses `-` as feature subtraction
-                for c in map_aarch64_arch_extension(name).chars() {
-                    mcpu.push(if c == '-' { '_' } else { c });
-                }
-            }
-            let mut result = vec![mcpu];
+            let (features, has_crypto) = map_aarch64_features(march_value);
+            let mut result = vec![format!("-mcpu={base_cpu}{features}")];
             if has_crypto {
                 result.append(&mut vec!["-Xassembler".to_owned(), arg.to_string()]);
             }
             return FilteredArg::Keep(result);
+        } else {
+            // -march values on the remaining architectures are CPU names,
+            // e.g. -march=x86-64-v3
+            let value = arg.strip_prefix("-march=").unwrap();
+            return FilteredArg::Keep(vec![format!("-march={}", map_cpu_name(value, target_info))]);
         }
+    }
+    if let Some((flag @ ("-mcpu" | "-mtune"), value)) = arg.split_once('=') {
+        if target_info.is_aarch64() || target_info.is_aarch64_be() {
+            let cpu = value.split('+').next().unwrap();
+            let (features, _) = map_aarch64_features(value);
+            return FilteredArg::Keep(vec![format!(
+                "{flag}={}{features}",
+                map_cpu_name(cpu, target_info)
+            )]);
+        }
+        return FilteredArg::Keep(vec![format!("{flag}={}", map_cpu_name(value, target_info))]);
     }
     if target_info.is_apple_platform() {
         if (zig_version.major, zig_version.minor) < (0, 16) {
@@ -668,6 +680,62 @@ fn filter_linker_arg(
         }
     }
     FilteredArg::Keep(vec![arg.to_string()])
+}
+
+/// Map the CPU-name part of a GCC/clang `-mcpu`/`-mtune`/`-march` value to
+/// zig's spelling: zig uses underscores where GCC/clang use dashes
+/// (e.g. cortex-a53 -> cortex_a53, x86-64-v3 -> x86_64_v3), and powerpc
+/// CPUs use the LLVM names (e.g. power9 -> pwr9). Any `+ext` suffixes are
+/// preserved as-is; zig-spelled values pass through unchanged.
+fn map_cpu_name(value: &str, target_info: &TargetInfo) -> String {
+    if target_info.is_s390x() {
+        // zig s390x CPU specs like z10-vector use `-` for feature
+        // subtraction, and GCC/clang s390x CPU names contain no dashes
+        return value.to_string();
+    }
+    let (cpu, features) = match value.find('+') {
+        Some(pos) => value.split_at(pos),
+        None => (value, ""),
+    };
+    if target_info.is_powerpc() {
+        let cpu = match cpu {
+            "powerpc" => "ppc".to_string(),
+            "powerpc64" => "ppc64".to_string(),
+            "powerpc64le" => "ppc64le".to_string(),
+            _ => match cpu.strip_prefix("power") {
+                Some(n) if n.starts_with(|c: char| c.is_ascii_digit()) => format!("pwr{n}"),
+                _ => cpu.to_string(),
+            },
+        };
+        return format!("{cpu}{features}");
+    }
+    format!("{}{features}", cpu.replace('-', "_"))
+}
+
+/// Convert the `+ext` suffixes of a GCC/clang aarch64 `-march`/`-mcpu` value
+/// (e.g. `armv8.2-a+sve+nofp16`) into zig's feature syntax (`+sve-fullfp16`).
+/// Returns the feature string and whether `+crypto` was requested.
+fn map_aarch64_features(value: &str) -> (String, bool) {
+    let mut extensions = value.split('+');
+    let _cpu_or_arch = extensions.next();
+    let mut features = String::new();
+    let mut has_crypto = false;
+    for ext in extensions.filter(|e| !e.is_empty() && *e != "none") {
+        has_crypto |= ext == "crypto";
+        // GCC/clang spell disabling an extension `+no<ext>`,
+        // zig's -mcpu spells it `-<feature>`
+        let (sign, name) = match ext.strip_prefix("no") {
+            Some(name) if !name.is_empty() => ('-', name),
+            _ => ('+', ext),
+        };
+        features.push(sign);
+        // zig spells multi-word feature names with underscores
+        // (e.g. sve2_aes) and parses `-` as feature subtraction
+        for c in map_aarch64_arch_extension(name).chars() {
+            features.push(if c == '-' { '_' } else { c });
+        }
+    }
+    (features, has_crypto)
 }
 
 /// Map GCC/clang aarch64 `-march` arch-extension names to the LLVM feature
@@ -2569,6 +2637,74 @@ mod tests {
                 "-march=armv8.2-a+nofp16+nosimd",
                 "aarch64-unknown-linux-gnu",
                 &["-mcpu=generic-fullfp16-neon"],
+            ),
+            // x86-64: -march values are CPU names, spelled with underscores in zig
+            (
+                "-march=x86-64-v3",
+                "x86_64-unknown-linux-gnu",
+                &["-march=x86_64_v3"],
+            ),
+            (
+                "-march=haswell",
+                "x86_64-unknown-linux-gnu",
+                &["-march=haswell"],
+            ),
+        ];
+        for (input, target, expected) in cases {
+            let result = run_filter_one(input, Some(target), (13, 0));
+            assert_eq!(&result, expected, "filter({input}, {target})");
+        }
+    }
+
+    #[test]
+    fn test_filter_mcpu_mtune_args() {
+        // (input, target, expected)
+        let cases: &[(&str, &str, &[&str])] = &[
+            // zig spells CPU names with underscores
+            (
+                "-mcpu=cortex-a53",
+                "aarch64-unknown-linux-gnu",
+                &["-mcpu=cortex_a53"],
+            ),
+            (
+                "-mcpu=cortex-a7",
+                "arm-unknown-linux-gnueabihf",
+                &["-mcpu=cortex_a7"],
+            ),
+            (
+                "-mtune=x86-64-v3",
+                "x86_64-unknown-linux-gnu",
+                &["-mtune=x86_64_v3"],
+            ),
+            // aarch64 -mcpu arch extensions are mapped like -march ones
+            (
+                "-mcpu=cortex-a53+crypto+nofp16",
+                "aarch64-unknown-linux-gnu",
+                &["-mcpu=cortex_a53+crypto-fullfp16"],
+            ),
+            // powerpc CPU names use the LLVM spellings
+            (
+                "-mcpu=power9",
+                "powerpc64le-unknown-linux-gnu",
+                &["-mcpu=pwr9"],
+            ),
+            (
+                "-mcpu=powerpc64le",
+                "powerpc64le-unknown-linux-gnu",
+                &["-mcpu=ppc64le"],
+            ),
+            // zig-spelled values pass through unchanged: `-` after a `+` is
+            // zig's feature subtraction, and s390x specs like z10-vector are
+            // never rewritten
+            (
+                "-mcpu=generic+v6+strict_align+vfp2-d32",
+                "arm-unknown-linux-gnueabihf",
+                &["-mcpu=generic+v6+strict_align+vfp2-d32"],
+            ),
+            (
+                "-mcpu=z10-vector",
+                "s390x-unknown-linux-gnu",
+                &["-mcpu=z10-vector"],
             ),
         ];
         for (input, target, expected) in cases {

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -1386,10 +1386,26 @@ impl Zig {
                 "-D_LIBCPP_HAS_UNICODE=1",
                 "-D_LIBCPP_HAS_THREADS=1",
                 "-D_LIBCPP_HAS_MONOTONIC_CLOCK",
+                // Required by zig 0.17+ libc++ (LLVM 21); harmless no-ops on
+                // older versions, which use the spellings above instead.
+                // Should match `addCxxArgs` in zig's src/libs/libcxx.zig
+                "-D_LIBCPP_ASSERTION_SEMANTIC_DEFAULT=_LIBCPP_ASSERTION_SEMANTIC_ENFORCE",
+                "-D_LIBCPP_PSTL_BACKEND_SERIAL",
+                "-D_LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS=0",
+                "-D_LIBCPP_HAS_TERMINAL",
+                "-D_LIBCPP_HAS_RANDOM_DEVICE",
+                "-D_LIBCPP_HAS_NO_STD_MODULES",
             ]
             .into_iter()
             .map(ToString::to_string),
         );
+        args.push(format!(
+            "-D_LIBCPP_HAS_FILESYSTEM={}",
+            if raw_target.contains("wasi") { 0 } else { 1 }
+        ));
+        if raw_target.contains("linux") {
+            args.push("-D_LIBCPP_HAS_TIME_ZONE_DATABASE".to_owned());
+        }
         if let Some(ver) = c_opts.glibc_minor_ver {
             // Handled separately because we have no way to infer this without Zig
             args.push(format!("-D__GLIBC_MINOR__={ver}"));

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -607,18 +607,28 @@ fn filter_linker_arg(
             && (target_info.is_aarch64() || target_info.is_aarch64_be())
         {
             let march_value = arg.strip_prefix("-march=").unwrap();
-            let features = if let Some(pos) = march_value.find('+') {
-                &march_value[pos..]
-            } else {
-                ""
-            };
+            let mut extensions = march_value.split('+');
+            let _arch = extensions.next();
             let base_cpu = if target_info.is_apple_platform() {
                 target_info.apple_cpu()
             } else {
                 "generic"
             };
-            let mut result = vec![format!("-mcpu={}{}", base_cpu, features)];
-            if features.contains("+crypto") {
+            let mut mcpu = format!("-mcpu={base_cpu}");
+            let mut has_crypto = false;
+            for ext in extensions.filter(|e| !e.is_empty() && *e != "none") {
+                has_crypto |= ext == "crypto";
+                // GCC/clang spell disabling an extension `+no<ext>`,
+                // zig's -mcpu spells it `-<feature>`
+                let (sign, name) = match ext.strip_prefix("no") {
+                    Some(name) if !name.is_empty() => ('-', name),
+                    _ => ('+', ext),
+                };
+                mcpu.push(sign);
+                mcpu.push_str(map_aarch64_arch_extension(name));
+            }
+            let mut result = vec![mcpu];
+            if has_crypto {
                 result.append(&mut vec!["-Xassembler".to_owned(), arg.to_string()]);
             }
             return FilteredArg::Keep(result);
@@ -654,6 +664,27 @@ fn filter_linker_arg(
         }
     }
     FilteredArg::Keep(vec![arg.to_string()])
+}
+
+/// Map GCC/clang aarch64 `-march` arch-extension names to the LLVM feature
+/// names understood by zig's `-mcpu` parser, e.g. `fp16` -> `fullfp16`
+///
+/// The mapping comes from the `ExtensionWithMArch` definitions in
+/// https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64Features.td
+fn map_aarch64_arch_extension(ext: &str) -> &str {
+    match ext {
+        "fp" => "fp-armv8",
+        "fp16" => "fullfp16",
+        "simd" => "neon",
+        "profile" => "spe",
+        "rng" => "rand",
+        "memtag" => "mte",
+        "pmuv3" => "perfmon",
+        "jscvt" => "jsconv",
+        "fcma" => "complxnum",
+        "predres2" => "specres2",
+        _ => ext,
+    }
 }
 
 impl Zig {
@@ -2509,6 +2540,24 @@ mod tests {
                 "-march=armv8.4-a",
                 "aarch64-apple-darwin",
                 &["-mcpu=apple_m1"],
+            ),
+            // aarch64: GCC/clang extension names mapped to LLVM feature names
+            // https://github.com/rust-cross/cargo-zigbuild/issues/456
+            (
+                "-march=armv8.2-a+sve+fp16",
+                "aarch64-unknown-linux-musl",
+                &["-mcpu=generic+sve+fullfp16"],
+            ),
+            (
+                "-march=armv8.2-a+simd+profile+rng+memtag",
+                "aarch64-unknown-linux-gnu",
+                &["-mcpu=generic+neon+spe+rand+mte"],
+            ),
+            // aarch64: `+no<ext>` disables a feature
+            (
+                "-march=armv8.2-a+nofp16+nosimd",
+                "aarch64-unknown-linux-gnu",
+                &["-mcpu=generic-fullfp16-neon"],
             ),
         ];
         for (input, target, expected) in cases {


### PR DESCRIPTION
Fixes #456

GCC/clang and zig spell CPU and feature names differently, and cargo-zigbuild forwarded the GCC/clang spellings verbatim, so valid compiler flags from build scripts failed in zig (or worse, silently misbehaved). Three related fixes:

## 1. aarch64 `-march` arch-extension names (the issue)

The `-march=armv...` → `-mcpu=...` rewrite passed extension names through verbatim, but zig only accepts LLVM feature names: `-march=armv8.2-a+sve+fp16` (used by `tract-linalg`'s build script) failed with `error: unknown CPU feature: 'fp16'`.

Added an alias table for the `-march` extension spellings that diverge from the LLVM feature name, per the `ExtensionWithMArch` definitions in [LLVM's AArch64Features.td](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64Features.td): `fp`→`fp-armv8`, `fp16`→`fullfp16`, `simd`→`neon`, `profile`→`spe`, `rng`→`rand`, `memtag`→`mte`, `pmuv3`→`perfmon`, `jscvt`→`jsconv`, `fcma`→`complxnum`, `predres2`→`specres2`. Extensions are now parsed individually; the GCC/clang `+no<ext>` negation form is translated to zig's `-<feature>` and the no-op `+none` is dropped. The `+crypto` → `-Xassembler -march=...` behavior is preserved.

## 2. Dashed feature names silently subtracted

zig spells multi-word feature names with underscores and parses `-` in `-mcpu` as feature *subtraction*, so `+sve2-aes` compiled without error but actually meant "enable sve2, **disable** aes" (verified via `__ARM_FEATURE_*` macros). Mapped feature names now have dashes converted to underscores (`sve2-aes` → `sve2_aes`, `fp` → `fp_armv8`).

## 3. Dashed CPU names on `-mcpu`/`-mtune`/`-march`

The same clash affects CPU names: `-mcpu=cortex-a53`, `-mcpu=cortex-a7`, `-march=x86-64-v3`, `-mtune=x86-64-v3` all failed (e.g. `unknown CPU: 'x86'` — zig parsed the `-` as subtraction). Now the CPU-name part of `-mcpu`/`-mtune` values (and of `-march` values on architectures where they are CPU names) is normalized to zig's underscore spelling, powerpc CPU names are mapped to the LLVM spellings (`power9`→`pwr9`, `powerpc64le`→`ppc64le`), and aarch64 `-mcpu` `+ext` suffixes get the same extension mapping as `-march`.

zig-spelled values pass through unchanged: `-` after a `+` is left alone (e.g. cargo-zigbuild's own `generic+v6+strict_align+vfp2-d32` for arm), and s390x is excluded entirely since specs like `z10-vector` use `-` for subtraction while GCC/clang s390x CPU names contain no dashes.

## Testing

- Unit tests in `test_filter_march_args` and `test_filter_mcpu_mtune_args` cover the issue's exact string, the aliases, `+no<ext>`, dashed features, dashed CPU names per target, powerpc mappings, and the zig-spelled passthrough cases
- Verified end-to-end with zig 0.16: the issue's failing command (`-march=armv8.2-a+sve+fp16` with the SVE/f16 test source) compiles; `+sve2-aes` now defines `__ARM_FEATURE_SVE2_AES`; and `-march=x86-64-v3`, `-mtune=x86-64-v3`, `-mcpu=cortex-a53+crypto+nofp16`, `-mcpu=cortex-a7` (arm32), `-mcpu=power9` (ppc64le), and `-mcpu=z10-vector` (s390x passthrough) all build

## 4. zig master (LLVM 21) libc++ bindgen breakage

Unrelated to the above but folded in to fix the red `zig: master` CI jobs (which also fail on `main` — they are `continue-on-error`): LLVM 21's libc++ requires `_LIBCPP_ASSERTION_SEMANTIC_DEFAULT` to be defined at configuration time, so `Test bindgen-exhaustive` failed against zig `0.17.0-dev` with `error: _LIBCPP_ASSERTION_SEMANTIC_DEFAULT is not defined`. Added it (paired with the existing `_LIBCPP_HARDENING_MODE_FAST` as zig does) plus the renamed/new config defines from zig master's `addCxxArgs` in [`src/libs/libcxx.zig`](https://codeberg.org/ziglang/zig/src/branch/master/src/libs/libcxx.zig) to the synthesized `BINDGEN_EXTRA_CLANG_ARGS`, keeping the old spellings for zig ≤ 0.16 where the new ones are harmless no-ops.

Verified locally with the exact CI nightly (`0.17.0-dev.1862+40ebd8162`): reproduced the CI failure without the change, and with it all three `bindgen-exhaustive` targets (`aarch64-unknown-linux-gnu`, `x86_64-pc-windows-gnu`, `aarch64-apple-darwin`) build; regression-checked against zig 0.16.0.

## 5. Rust nightly arm link failure (`__aeabi_uread4`)

The other pre-existing red CI rows (all Rust *nightly* jobs, also failing on `main`): linking `hello-rustls` for `arm-unknown-linux-gnueabihf` fails with `ld.lld: error: undefined symbol: __aeabi_uread4`. Recent nightlies' prebuilt libstd (between 2026-08-01 and 2026-08-25) emit calls to the ARM RTABI unaligned-access helpers on strict-align arm targets; libgcc provides them, but LLVM's (and zig's) compiler-rt does not. Fixed by linking weak definitions of the four helpers (`__aeabi_uread4/uwrite4/uread8/uwrite8`, IHI0043 §4.3.3) when linking 32-bit arm targets — weak so they defer to any future compiler-rt implementation, and `--gc-sections` drops them when unused.

Verified locally: reproduced with nightly 2026-08-25 (nightly 2026-08-01 still passed), and with the fix `hello-rustls` links for `arm-unknown-linux-gnueabihf` and `armv7-unknown-linux-gnueabihf` on that nightly; regression-checked arm gnu/musl builds on stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nQDk7hJtCdwndXgs7WpTc
