### PR TITLE
fix: make bindgen include-path pre/post arithmetic panic-proof

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -1295,21 +1295,20 @@ impl Zig {
         }
         let c_paths = c_opts.include_paths;
         let mut cpp_paths = cpp_opts.include_paths;
-        let cpp_pre_len = cpp_paths
+        // The C++ search list is expected to be the C search list with extra
+        // libc++ paths prepended and appended, but zig's layout has varied
+        // across versions/targets, so fall back to zero-length pre/post
+        // regions instead of panicking when a shared path can't be found.
+        let cpp_pre_len = c_paths
             .iter()
-            .position(|p| {
-                p == c_paths
-                    .iter()
-                    .find(|(kind, _)| *kind == Kind::Normal)
-                    .unwrap()
-            })
+            .find(|(kind, _)| *kind == Kind::Normal)
+            .and_then(|first_c| cpp_paths.iter().position(|p| p == first_c))
             .unwrap_or_default();
-        let cpp_post_len = cpp_paths.len()
-            - cpp_paths
-                .iter()
-                .position(|p| p == c_paths.last().unwrap())
-                .unwrap_or_default()
-            - 1;
+        let cpp_post_len = c_paths
+            .last()
+            .and_then(|last_c| cpp_paths.iter().rposition(|p| p == last_c))
+            .map(|pos| cpp_paths.len() - pos - 1)
+            .unwrap_or_default();
 
         // <digression>
         //
@@ -1454,8 +1453,12 @@ impl Zig {
             }
         }
 
-        for (kind, path) in cpp_paths.drain(cpp_paths.len() - cpp_post_len..) {
-            assert!(kind == Kind::Normal);
+        let post_start = cpp_paths.len().saturating_sub(cpp_post_len);
+        for (kind, path) in cpp_paths.drain(post_start..) {
+            if kind != Kind::Normal {
+                // may also be Kind::Framework on macOS
+                continue;
+            }
             args.push("-cxx-isystem".to_owned());
             args.push(path);
         }


### PR DESCRIPTION
## Summary

Fixes the panic reported in #364:

```
range start index 18446744073709551614 out of range for slice of length 2
```

`collect_zig_cc_options` assumes zig's C++ include search list is the C search list with libc++ paths prepended/appended. When the tail C path isn't found in the C++ list (the layout has varied across zig versions/targets), `position().unwrap_or_default()` silently yielded position 0, making `cpp_post_len = len - 1` and underflowing the second `drain`'s start index after the first drain had already shrunk the vec — `-2 as usize`, exactly the reported panic.

Changes:
- Anchor the pre/post regions with explicit `Option` handling — a missing anchor now means an empty region instead of a bogus one (also removes two `.unwrap()`s that could panic on an empty C path list).
- `saturating_sub` for the tail drain start so no layout can underflow.
- Tolerate non-`Normal` path kinds in the tail (skip, matching the head loop) instead of `assert!`.

## Verification

- `cargo test --lib` passes.
- `cargo zigbuild --target x86_64-pc-windows-gnu` on `tests/hello-windows` exercises the changed code path and builds cleanly.
- On zig 0.16.0 the C/C++ include layouts match the assumption, so behavior is unchanged in the common case; the fix matters for zig builds where they don't (as in the reporter's nightly `-Zbuild-std` windows-gnu environment).

Fixes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1Kk6AucizDRZdBDVGipXF