### PR TITLE
perf: cache resolved zig command in wrapper scripts to skip per-invocation probes

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -910,6 +910,20 @@ impl Zig {
         if let Some(cached) = ZIG_PATH.get() {
             return Ok(cached.clone());
         }
+        // Trust the zig command resolved when the linker wrapper was generated;
+        // this avoids spawning `python -m ziglang version` and `zig version`
+        // probes on every compiler invocation.
+        if let Ok(path) = env::var("CARGO_ZIGBUILD_ZIG_COMMAND")
+            && !path.is_empty()
+        {
+            let path = PathBuf::from(path);
+            if path.exists() {
+                let args = env::var("CARGO_ZIGBUILD_ZIG_COMMAND_ARGS")
+                    .map(|s| s.split_whitespace().map(ToString::to_string).collect())
+                    .unwrap_or_default();
+                return Ok(ZIG_PATH.get_or_init(|| (path, args)).clone());
+            }
+        }
         let result = Self::find_zig_python()
             .or_else(|_| Self::find_zig_bin())
             .context("Failed to find zig")?;
@@ -2102,9 +2116,10 @@ pub fn prepare_zig_linker(
     let zig_cxx = wrapper_dir.join(format!("zigcxx-{file_target}-{:x}.{file_ext}", hash));
     let zig_ranlib = wrapper_dir.join(format!("zigranlib.{file_ext}"));
     let zig_version = Zig::zig_version()?;
-    write_linker_wrapper(&zig_cc, "cc", &cc_args_str, &zig_version)?;
-    write_linker_wrapper(&zig_cxx, "c++", &cc_args_str, &zig_version)?;
-    write_linker_wrapper(&zig_ranlib, "ranlib", "", &zig_version)?;
+    let zig_command = Zig::find_zig()?;
+    write_linker_wrapper(&zig_cc, "cc", &cc_args_str, &zig_version, &zig_command)?;
+    write_linker_wrapper(&zig_cxx, "c++", &cc_args_str, &zig_version, &zig_command)?;
+    write_linker_wrapper(&zig_ranlib, "ranlib", "", &zig_version, &zig_command)?;
 
     let exe_ext = if cfg!(windows) { ".exe" } else { "" };
     let zig_ar = wrapper_dir.join(format!("ar{exe_ext}"));
@@ -2235,6 +2250,7 @@ fn write_linker_wrapper(
     command: &str,
     args: &str,
     zig_version: &semver::Version,
+    zig_command: &(PathBuf, Vec<String>),
 ) -> Result<()> {
     let mut buf = Vec::<u8>::new();
     let current_exe = resolve_current_exe()?;
@@ -2246,6 +2262,20 @@ fn write_linker_wrapper(
         "export CARGO_ZIGBUILD_ZIG_VERSION={}",
         zig_version
     )?;
+    // Export the resolved zig command to avoid re-probing for
+    // `python -m ziglang` / `zig` on every compiler invocation
+    writeln!(
+        &mut buf,
+        "export CARGO_ZIGBUILD_ZIG_COMMAND={}",
+        shell_words::quote(&zig_command.0.to_string_lossy())
+    )?;
+    if !zig_command.1.is_empty() {
+        writeln!(
+            &mut buf,
+            "export CARGO_ZIGBUILD_ZIG_COMMAND_ARGS={}",
+            shell_words::quote(&zig_command.1.join(" "))
+        )?;
+    }
 
     // Pass through SDKROOT if it exists at runtime
     writeln!(&mut buf, "if [ -n \"$SDKROOT\" ]; then export SDKROOT; fi")?;
@@ -2281,6 +2311,7 @@ fn write_linker_wrapper(
     command: &str,
     args: &str,
     zig_version: &semver::Version,
+    zig_command: &(PathBuf, Vec<String>),
 ) -> Result<()> {
     let mut buf = Vec::<u8>::new();
     let current_exe = resolve_current_exe()?;
@@ -2294,6 +2325,20 @@ fn write_linker_wrapper(
     writeln!(&mut buf, "setlocal DisableDelayedExpansion")?;
     // Set zig version to avoid spawning `zig version` subprocess
     writeln!(&mut buf, "set CARGO_ZIGBUILD_ZIG_VERSION={}", zig_version)?;
+    // Set the resolved zig command to avoid re-probing for
+    // `python -m ziglang` / `zig` on every compiler invocation
+    writeln!(
+        &mut buf,
+        "set \"CARGO_ZIGBUILD_ZIG_COMMAND={}\"",
+        zig_command.0.display()
+    )?;
+    if !zig_command.1.is_empty() {
+        writeln!(
+            &mut buf,
+            "set \"CARGO_ZIGBUILD_ZIG_COMMAND_ARGS={}\"",
+            zig_command.1.join(" ")
+        )?;
+    }
     writeln!(
         &mut buf,
         "\"{}\" zig {} -- {} %*",


### PR DESCRIPTION
## Summary

Addresses the per-invocation overhead measured in #244.

`find_zig()` runs on every `cargo-zigbuild zig cc` invocation and always spawned two processes before doing any work:
1. `python -m ziglang version` — paying full Python interpreter startup (~15ms) just to fail on systems without the pip package,
2. `zig version` — ~31ms of zig startup for validation, even though `CARGO_ZIGBUILD_ZIG_VERSION` already carries the version.

The toolchain was already resolved and validated when the wrapper script was generated, so re-probing per compile is pure waste — for C-heavy builds it's paid hundreds of times.

This exports the resolved command as `CARGO_ZIGBUILD_ZIG_COMMAND` (+ `CARGO_ZIGBUILD_ZIG_COMMAND_ARGS` for the `python -m ziglang` mode) in the generated sh and bat wrappers, and has `find_zig()` trust it when the path still exists — falling back to the normal probe order if it doesn't (e.g. zig was moved between builds; the next wrapper regeneration re-resolves).

## Numbers (macOS, zig 0.16.0, hyperfine, real-build env)

| | before | after |
|---|---|---|
| wrapper `-###` call | 87 ms | 44 ms |
| raw `zig cc -###` | 33 ms | 33 ms |
| **overhead** | **~52 ms** | **~11 ms** |

The remaining ~11ms is sh + cargo-zigbuild binary startup and arg filtering.

Verified: `cargo test --lib` passes; real builds for `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu.2.17` regenerate wrappers with the new exports and build cleanly. Clippy warnings are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1Kk6AucizDRZdBDVGipXF