### PR TITLE
feat: honor rustflags from cargo's --config CLI option for zig -mcpu

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -141,6 +141,23 @@ jobs:
           else
             echo "Test pass"
           fi
+      - name: Test --config target-cpu
+        shell: bash
+        run: |
+          set -e
+          echo "Running --config target.x86_64-unknown-linux-gnu.rustflags=['-C','target-cpu=x86-64-v4']..."
+          echo
+          # Clean so the artifact from the RUSTFLAGS test above can't be reused
+          rm -rf tests/target-cpu/target
+          target/debug/cargo-zigbuild zigbuild --manifest-path tests/target-cpu/Cargo.toml --target x86_64-unknown-linux-gnu --release --config "target.x86_64-unknown-linux-gnu.rustflags=['-C','target-cpu=x86-64-v4']"
+          x86-instruction-set-analyzer tests/target-cpu/target/x86_64-unknown-linux-gnu/release/target-cpu | tee output.txt
+          echo
+          if ! grep -q 'AVX2' output.txt; then
+            echo "Test fail, should contain AVX2 instruction set"
+            false
+          else
+            echo "Test pass"
+          fi
       - name: macOS - Test build
         run: |
           cargo run zigbuild --target aarch64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "shell-words",
  "target-lexicon",
  "tempfile",
+ "toml",
  "which",
 ]
 
@@ -675,10 +676,12 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -699,6 +702,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 shell-words = "1.1.1"
 target-lexicon = { version = "0.13.0", features = ["std"] }
+toml = "1.1"
 which = "8.0.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ RUSTFLAGS='-C target-cpu=neoverse-n1' cargo zigbuild --release --target aarch64-
 
 `cargo zigbuild` picks up `-C target-cpu` and passes a matching `-mcpu` to `zig cc` so that C/C++ dependencies are built for the same CPU.
 
+Since environment variables can't be set in cargo aliases, you can also pass the rustflags via cargo's `--config` option — `cargo zigbuild` honors it the same way:
+
+```bash
+cargo zigbuild --release --target x86_64-unknown-linux-gnu \
+    --config "target.x86_64-unknown-linux-gnu.rustflags=['-C', 'target-cpu=x86-64-v4']"
+```
+
+This makes it possible to scope a `target-cpu` to a specific alias in `.cargo/config.toml` instead of applying it to every build for that target:
+
+```toml
+[alias]
+build-prod = "zigbuild --release --target x86_64-unknown-linux-gnu --config target.x86_64-unknown-linux-gnu.rustflags=['-C','target-cpu=x86-64-v4']"
+```
+
 Conversely, if a binary built for `x86_64-unknown-linux-gnu` dies with `Illegal instruction` on older hardware, check whether your `RUSTFLAGS`/`.cargo/config.toml` sets a `target-cpu` newer than the machines you deploy to.
 
 ### macOS universal2 target

--- a/src/zig/cargo_env.rs
+++ b/src/zig/cargo_env.rs
@@ -20,7 +20,9 @@ use crate::linux::ARM_FEATURES_H;
 use crate::macos::{LIBCHARSET_TBD, LIBICONV_TBD};
 
 use super::locate::cache_dir;
-use super::wrapper::{ZigWrapper, is_mingw_shell, prepare_zig_linker, symlink_wrapper};
+use super::wrapper::{
+    ZigWrapper, is_mingw_shell, prepare_zig_linker_with_cli_config, symlink_wrapper,
+};
 use super::{Zig, has_system_dlltool};
 
 impl Zig {
@@ -82,7 +84,8 @@ impl Zig {
         let host_target = &rustc_meta.host;
         for (parsed_target, raw_target) in rust_targets.iter().zip(raw_targets) {
             let env_target = parsed_target.replace('-', "_");
-            let zig_wrapper = prepare_zig_linker(raw_target, &cargo_config)?;
+            let zig_wrapper =
+                prepare_zig_linker_with_cli_config(raw_target, &cargo_config, &cargo.config)?;
 
             if is_mingw_shell() {
                 let zig_cc = zig_wrapper.cc.to_slash_lossy();

--- a/src/zig/cli_config.rs
+++ b/src/zig/cli_config.rs
@@ -1,0 +1,307 @@
+//! Rustflags extraction from cargo's `--config` CLI option.
+//!
+//! Cargo accepts arbitrary configuration overrides via `--config KEY=VALUE`
+//! (TOML syntax) or `--config <path>.toml`. cargo-zigbuild forwards these to
+//! the child cargo process, but `cargo_config2::Config::load()` only reads
+//! config files and environment variables, so `target-cpu` set via `--config`
+//! would silently not be reflected in the `-mcpu` passed to `zig cc`. This
+//! module parses the `--config` arguments so that rustflags provided this way
+//! participate in the resolution used for zig's `-mcpu`.
+//!
+//! Once cargo-config2 natively supports `--config` CLI overrides
+//! (<https://github.com/taiki-e/cargo-config2/issues/3>), most of this module
+//! (in particular the tier heuristic in [`CliConfig::overlay`]) can be
+//! replaced with that API.
+
+use std::collections::BTreeMap;
+use std::env;
+
+use anyhow::{Context, Result};
+use cargo_config2::Flags;
+
+/// Rustflags provided via cargo's `--config` CLI option.
+///
+/// Cargo merges `--config` values in left-to-right order with the same logic
+/// used for config files: arrays are joined with higher precedence items
+/// placed later. CLI values take precedence over config files and config
+/// environment variables (`CARGO_TARGET_<T>_RUSTFLAGS`, `CARGO_BUILD_RUSTFLAGS`),
+/// but not over the `RUSTFLAGS`/`CARGO_ENCODED_RUSTFLAGS` environment
+/// variables, which shortcut the rustflags resolution entirely.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CliConfig {
+    build_rustflags: Option<Flags>,
+    target_rustflags: BTreeMap<String, Flags>,
+}
+
+impl CliConfig {
+    /// Parses cargo `--config` arguments (`KEY=VALUE` in TOML syntax, or a
+    /// path to an extra config file ending in `.toml`).
+    ///
+    /// `target.'cfg(...)'` keys are ignored because evaluating cfg
+    /// expressions requires querying rustc; cargo still applies them to the
+    /// actual build, they just don't influence zig's `-mcpu`.
+    pub fn parse(config_args: &[String]) -> Result<Self> {
+        let mut parsed = Self::default();
+        for arg in config_args {
+            // Cargo treats an argument ending in `.toml` as a path to an
+            // extra config file; anything else must be TOML `KEY=VALUE`.
+            let config: cargo_config2::de::Config = if arg.ends_with(".toml") {
+                cargo_config2::de::Config::load_file(arg)?
+            } else {
+                toml::from_str(arg)
+                    .with_context(|| format!("failed to parse --config argument `{arg}`"))?
+            };
+            if let Some(flags) = &config.build.rustflags {
+                append_de_flags(parsed.build_rustflags.get_or_insert_default(), flags);
+            }
+            for (key, target_config) in &config.target {
+                if key.starts_with("cfg(") {
+                    continue;
+                }
+                if let Some(flags) = &target_config.rustflags {
+                    append_de_flags(
+                        parsed.target_rustflags.entry(key.clone()).or_default(),
+                        flags,
+                    );
+                }
+            }
+        }
+        Ok(parsed)
+    }
+
+    /// Resolves the effective rustflags for `rust_target`, overlaying the
+    /// CLI-provided values onto the config file/environment resolution.
+    ///
+    /// Cargo resolves rustflags from four mutually exclusive sources, in
+    /// order, using the first one that is set:
+    ///
+    /// 1. `CARGO_ENCODED_RUSTFLAGS` environment variable
+    /// 2. `RUSTFLAGS` environment variable
+    /// 3. all matching `target.<triple>.rustflags` and `target.<cfg>.rustflags`
+    ///    config entries joined together
+    /// 4. `build.rustflags` config value
+    ///
+    /// `--config` values participate in sources 3 and 4 with the highest
+    /// precedence within those sources (joined last).
+    pub fn rustflags(
+        &self,
+        cargo_config: &cargo_config2::Config,
+        rust_target: &str,
+    ) -> Result<Option<Flags>> {
+        let resolved = cargo_config.rustflags(rust_target)?;
+        if env::var_os("CARGO_ENCODED_RUSTFLAGS").is_some() || env::var_os("RUSTFLAGS").is_some() {
+            // Environment rustflags win over all config values, including CLI.
+            return Ok(resolved);
+        }
+        Ok(self.overlay(rust_target, resolved, cargo_config.build.rustflags.clone()))
+    }
+
+    /// Pure overlay of the CLI-provided rustflags onto the resolved config
+    /// values.
+    ///
+    /// `resolved` is the config file/environment resolution for the target
+    /// (source 3 if any target entries matched, source 4 otherwise) and
+    /// `build_flags` is the resolved `build.rustflags`. cargo_config2 does
+    /// not expose which source `resolved` came from, so when it equals
+    /// `build_flags` we assume it came from `build.rustflags`.
+    fn overlay(
+        &self,
+        rust_target: &str,
+        resolved: Option<Flags>,
+        build_flags: Option<Flags>,
+    ) -> Option<Flags> {
+        let from_build_tier = resolved == build_flags;
+        if let Some(cli_target) = self.target_rustflags.get(rust_target) {
+            // CLI target flags activate source 3: join file/env target
+            // entries (if any) with the CLI entries placed last;
+            // `build.rustflags` no longer applies.
+            let mut flags = if from_build_tier {
+                Flags::default()
+            } else {
+                resolved.unwrap_or_default()
+            };
+            flags.flags.extend(cli_target.flags.iter().cloned());
+            Some(flags)
+        } else if let Some(cli_build) = &self.build_rustflags {
+            if from_build_tier {
+                let mut flags = resolved.unwrap_or_default();
+                flags.flags.extend(cli_build.flags.iter().cloned());
+                Some(flags)
+            } else {
+                // A target.<triple>.rustflags entry matched; source 3 wins
+                // and build.rustflags (including the CLI value) is ignored.
+                resolved
+            }
+        } else {
+            resolved
+        }
+    }
+}
+
+fn append_de_flags(flags: &mut Flags, de_flags: &cargo_config2::de::Flags) {
+    flags
+        .flags
+        .extend(de_flags.flags.iter().map(|value| value.val.clone()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const TARGET: &str = "x86_64-unknown-linux-gnu";
+
+    fn flags(s: &str) -> Flags {
+        Flags::from_space_separated(s)
+    }
+
+    #[test]
+    fn test_parse_target_rustflags_array() {
+        let config = CliConfig::parse(&[format!(
+            "target.{TARGET}.rustflags=['-C','target-cpu=x86-64-v4']"
+        )])
+        .unwrap();
+        assert_eq!(
+            config.target_rustflags[TARGET].flags,
+            vec!["-C", "target-cpu=x86-64-v4"]
+        );
+        assert!(config.build_rustflags.is_none());
+    }
+
+    #[test]
+    fn test_parse_target_rustflags_string() {
+        let config = CliConfig::parse(&[format!(
+            "target.{TARGET}.rustflags='-C target-cpu=x86-64-v4'"
+        )])
+        .unwrap();
+        assert_eq!(
+            config.target_rustflags[TARGET].flags,
+            vec!["-C", "target-cpu=x86-64-v4"]
+        );
+    }
+
+    #[test]
+    fn test_parse_build_rustflags() {
+        let config =
+            CliConfig::parse(&["build.rustflags=['-Ctarget-cpu=neoverse-n1']".to_string()])
+                .unwrap();
+        assert_eq!(
+            config.build_rustflags.unwrap().flags,
+            vec!["-Ctarget-cpu=neoverse-n1"]
+        );
+    }
+
+    #[test]
+    fn test_parse_multiple_args_join_left_to_right() {
+        let config = CliConfig::parse(&[
+            format!("target.{TARGET}.rustflags=['-Ctarget-cpu=x86-64-v2']"),
+            format!("target.{TARGET}.rustflags=['-Ctarget-cpu=x86-64-v4']"),
+        ])
+        .unwrap();
+        // Arrays are joined with later (higher precedence) items placed last.
+        assert_eq!(
+            config.target_rustflags[TARGET].flags,
+            vec!["-Ctarget-cpu=x86-64-v2", "-Ctarget-cpu=x86-64-v4"]
+        );
+    }
+
+    #[test]
+    fn test_parse_config_file() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        writeln!(
+            file,
+            "[target.{TARGET}]\nrustflags = ['-C', 'target-cpu=x86-64-v3']"
+        )
+        .unwrap();
+        let config = CliConfig::parse(&[file.path().to_str().unwrap().to_string()]).unwrap();
+        assert_eq!(
+            config.target_rustflags[TARGET].flags,
+            vec!["-C", "target-cpu=x86-64-v3"]
+        );
+    }
+
+    #[test]
+    fn test_parse_ignores_unrelated_and_cfg_keys() {
+        let config = CliConfig::parse(&[
+            "net.git-fetch-with-cli=true".to_string(),
+            "profile.release.lto=true".to_string(),
+            "target.'cfg(target_arch = \"x86_64\")'.rustflags=['-Ctarget-cpu=x86-64-v4']"
+                .to_string(),
+        ])
+        .unwrap();
+        assert_eq!(config, CliConfig::default());
+    }
+
+    #[test]
+    fn test_overlay_cli_target_replaces_build_tier() {
+        let config = CliConfig::parse(&[format!(
+            "target.{TARGET}.rustflags=['-Ctarget-cpu=x86-64-v4']"
+        )])
+        .unwrap();
+        // `resolved` came from build.rustflags: CLI target flags activate
+        // source 3 and build.rustflags no longer applies.
+        let result = config.overlay(
+            TARGET,
+            Some(flags("-Ctarget-cpu=x86-64-v2")),
+            Some(flags("-Ctarget-cpu=x86-64-v2")),
+        );
+        assert_eq!(result.unwrap().flags, vec!["-Ctarget-cpu=x86-64-v4"]);
+    }
+
+    #[test]
+    fn test_overlay_cli_target_joins_file_target_tier() {
+        let config = CliConfig::parse(&[format!(
+            "target.{TARGET}.rustflags=['-Ctarget-cpu=x86-64-v4']"
+        )])
+        .unwrap();
+        // `resolved` came from target.<triple>.rustflags in a config file:
+        // entries are joined with CLI values last, so the CLI target-cpu wins.
+        let result = config.overlay(TARGET, Some(flags("-Ctarget-cpu=x86-64-v2")), None);
+        assert_eq!(
+            result.unwrap().flags,
+            vec!["-Ctarget-cpu=x86-64-v2", "-Ctarget-cpu=x86-64-v4"]
+        );
+    }
+
+    #[test]
+    fn test_overlay_cli_target_other_triple_is_ignored() {
+        let config = CliConfig::parse(&[
+            "target.aarch64-unknown-linux-gnu.rustflags=['-Ctarget-cpu=neoverse-n1']".to_string(),
+        ])
+        .unwrap();
+        let result = config.overlay(TARGET, None, None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_overlay_cli_build_joins_build_tier() {
+        let config =
+            CliConfig::parse(&["build.rustflags=['-Ctarget-cpu=x86-64-v4']".to_string()]).unwrap();
+        let result = config.overlay(
+            TARGET,
+            Some(flags("-Ctarget-cpu=x86-64-v2")),
+            Some(flags("-Ctarget-cpu=x86-64-v2")),
+        );
+        assert_eq!(
+            result.unwrap().flags,
+            vec!["-Ctarget-cpu=x86-64-v2", "-Ctarget-cpu=x86-64-v4"]
+        );
+    }
+
+    #[test]
+    fn test_overlay_cli_build_ignored_when_target_tier_present() {
+        let config =
+            CliConfig::parse(&["build.rustflags=['-Ctarget-cpu=x86-64-v4']".to_string()]).unwrap();
+        // `resolved` differs from build.rustflags, so it came from a
+        // target.<triple>.rustflags entry, which wins over build.rustflags.
+        let result = config.overlay(TARGET, Some(flags("-Ctarget-cpu=x86-64-v2")), None);
+        assert_eq!(result.unwrap().flags, vec!["-Ctarget-cpu=x86-64-v2"]);
+    }
+
+    #[test]
+    fn test_overlay_no_cli_flags_keeps_resolved() {
+        let config = CliConfig::default();
+        let result = config.overlay(TARGET, Some(flags("-Ctarget-cpu=x86-64-v2")), None);
+        assert_eq!(result.unwrap().flags, vec!["-Ctarget-cpu=x86-64-v2"]);
+    }
+}

--- a/src/zig/mod.rs
+++ b/src/zig/mod.rs
@@ -1,4 +1,5 @@
 mod cargo_env;
+mod cli_config;
 mod linker_args;
 mod locate;
 mod target_info;
@@ -16,9 +17,10 @@ use linker_args::{FilteredArg, dedup_apple_link_libs, filter_linker_arg, filter_
 use locate::cache_dir;
 use target_info::TargetInfo;
 
+pub use cli_config::CliConfig;
 #[cfg(target_os = "windows")]
 pub use wrapper::adjust_canonicalization;
-pub use wrapper::{ZigWrapper, prepare_zig_linker};
+pub use wrapper::{ZigWrapper, prepare_zig_linker, prepare_zig_linker_with_cli_config};
 
 /// Zig linker wrapper
 #[derive(Clone, Debug, clap::Subcommand)]

--- a/src/zig/wrapper.rs
+++ b/src/zig/wrapper.rs
@@ -13,6 +13,7 @@ use fs_err as fs;
 use path_slash::PathBufExt;
 use target_lexicon::{Architecture, Environment, OperatingSystem, Triple};
 
+use super::cli_config::CliConfig;
 use super::locate::cache_dir;
 use super::{Zig, get_dlltool_name, has_system_dlltool};
 
@@ -75,6 +76,17 @@ impl TargetFlags {
 pub fn prepare_zig_linker(
     target: &str,
     cargo_config: &cargo_config2::Config,
+) -> Result<ZigWrapper> {
+    prepare_zig_linker_with_cli_config(target, cargo_config, &[])
+}
+
+/// Like [`prepare_zig_linker`], but additionally honors rustflags passed via
+/// cargo's `--config` CLI option (`config_args`) when deriving the `-mcpu`
+/// passed to `zig cc`.
+pub fn prepare_zig_linker_with_cli_config(
+    target: &str,
+    cargo_config: &cargo_config2::Config,
+    config_args: &[String],
 ) -> Result<ZigWrapper> {
     let (rust_target, abi_suffix) = target.split_once('.').unwrap_or((target, ""));
     let abi_suffix = if abi_suffix.is_empty() {
@@ -149,7 +161,10 @@ pub fn prepare_zig_linker(
     // commands like `cargo-zigbuild build` are invoked.
     // Currently we only override according to target_cpu.
     let zig_mcpu_override = {
-        let rust_flags = cargo_config.rustflags(rust_target)?.unwrap_or_default();
+        let cli_config = CliConfig::parse(config_args)?;
+        let rust_flags = cli_config
+            .rustflags(cargo_config, rust_target)?
+            .unwrap_or_default();
         let encoded_rust_flags = rust_flags.encode()?;
         let target_flags = TargetFlags::parse_from_encoded(OsStr::new(&encoded_rust_flags))?;
         // Note: zig uses _ instead of - for target_cpu and target_feature


### PR DESCRIPTION
Rustflags passed via cargo's `--config` option (`KEY=VALUE` in TOML syntax or a path to an extra config file) were forwarded to the child cargo process but not reflected in the `-mcpu` passed to `zig cc`, silently reverting to baseline CPU for C/C++ dependencies and linking.

Parse the `--config` arguments and overlay them onto the `cargo_config2`-resolved rustflags following cargo's precedence rules: `RUSTFLAGS`/`CARGO_ENCODED_RUSTFLAGS` env vars shortcut everything, CLI config beats config env vars and files within a tier, target tier beats build tier, and arrays join left-to-right with CLI items last.

This makes it possible to scope a target-cpu to a cargo alias without wrapper scripts or `RUSTFLAGS`:

    [alias]
    build-prod = "zigbuild --release --target x86_64-unknown-linux-gnu --config target.x86_64-unknown-linux-gnu.rustflags=['-C','target-cpu=x86-64-v4']"

Most of this can be simplified once `cargo-config2` supports `--config` overrides natively (taiki-e/cargo-config2#3).

Closes #463