### PR TITLE
feat: export resolved zig target to build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ on macOS, Windows and Linux you can also install zig from PyPI via `pip3 install
 | `CARGO_ZIGBUILD_ZIG_PATH` | Zig executable path (default: `zig`) |
 | `CARGO_ZIGBUILD_CACHE_DIR` | Cache directory for zig tools and wrappers |
 | `CARGO_ZIGBUILD_RUSTC_VERSION` | Override detected rustc version |
+| `CARGO_ZIGBUILD_TARGET` | Resolved zig target triple exported to build scripts, for example `x86_64-linux-gnu.2.36` (also `CARGO_ZIGBUILD_TARGET_<target>`, which is always set; the unsuffixed name only when a single `--target` is given) |
 | `SDKROOT` | Path to macOS SDK (auto-detected on macOS) |
 | `CMAKE_TOOLCHAIN_FILE` | Path to CMake toolchain file (also `CMAKE_TOOLCHAIN_FILE_<target>`, `TARGET_CMAKE_TOOLCHAIN_FILE`) |
 | `BINDGEN_EXTRA_CLANG_ARGS` | Extra clang arguments for bindgen (also `BINDGEN_EXTRA_CLANG_ARGS_<target>`) |

--- a/src/zig/cargo_env.rs
+++ b/src/zig/cargo_env.rs
@@ -82,10 +82,37 @@ impl Zig {
             rustc_meta.semver.to_string(),
         );
         let host_target = &rustc_meta.host;
+        // This is an output, so any CARGO_ZIGBUILD_TARGET* inherited from an outer
+        // cargo zigbuild is stale; drop it before exporting the ones for this build.
+        for (key, _) in env::vars_os() {
+            let mut name = key.to_string_lossy();
+            // Windows environment variables are case-insensitive, Unix ones are not
+            if cfg!(windows) {
+                name = name.to_ascii_uppercase().into();
+            }
+            if name == "CARGO_ZIGBUILD_TARGET" || name.starts_with("CARGO_ZIGBUILD_TARGET_") {
+                cmd.env_remove(&key);
+            }
+        }
+
         for (parsed_target, raw_target) in rust_targets.iter().zip(raw_targets) {
             let env_target = parsed_target.replace('-', "_");
             let zig_wrapper =
                 prepare_zig_linker_with_cli_config(raw_target, &cargo_config, &cargo.config)?;
+
+            // Export the resolved zig target for build scripts that do not go
+            // through `cc` and so cannot recover the glibc version. Unlike the
+            // variables around it this is an output, so a value inherited from an
+            // outer build is stale rather than an override, and is replaced.
+            // The unsuffixed name is single-target only, since one variable cannot
+            // answer for several targets.
+            cmd.env(
+                format!("CARGO_ZIGBUILD_TARGET_{env_target}"),
+                &zig_wrapper.target,
+            );
+            if raw_targets.len() == 1 {
+                cmd.env("CARGO_ZIGBUILD_TARGET", &zig_wrapper.target);
+            }
 
             if is_mingw_shell() {
                 let zig_cc = zig_wrapper.cc.to_slash_lossy();

--- a/src/zig/wrapper.rs
+++ b/src/zig/wrapper.rs
@@ -17,7 +17,7 @@ use super::cli_config::CliConfig;
 use super::locate::cache_dir;
 use super::{Zig, get_dlltool_name, has_system_dlltool};
 
-/// zig wrapper paths
+/// zig wrapper paths, and the zig target they were prepared for
 #[derive(Debug, Clone)]
 pub struct ZigWrapper {
     pub cc: PathBuf,
@@ -25,6 +25,7 @@ pub struct ZigWrapper {
     pub ar: PathBuf,
     pub ranlib: PathBuf,
     pub lib: PathBuf,
+    pub target: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -110,13 +111,7 @@ pub fn prepare_zig_linker_with_cli_config(
         .parse()
         .with_context(|| format!("Unsupported Rust target '{rust_target}'"))?;
     let arch = triple.architecture.to_string();
-    let target_env = match (triple.architecture, triple.environment) {
-        (Architecture::Mips32(..), Environment::Gnu) => Environment::Gnueabihf,
-        (Architecture::Mips32(..), Environment::Musl) => Environment::Musleabi,
-        (Architecture::Powerpc, Environment::Gnu) => Environment::Gnueabihf,
-        (_, Environment::GnuLlvm) => Environment::Gnu,
-        (_, environment) => environment,
-    };
+    let target_env = zig_target_env(&triple);
     let file_ext = if cfg!(windows) { "bat" } else { "sh" };
     let file_target = target.trim_end_matches('.');
 
@@ -178,118 +173,15 @@ pub fn prepare_zig_linker_with_cli_config(
         cc_args.push(format!("-mcpu={zig_mcpu_default}"));
     }
 
-    match triple.operating_system {
-        OperatingSystem::Linux => {
-            let zig_arch = match arch.as_str() {
-                // zig uses _ instead of - in cpu features
-                "arm" => "arm",
-                "armv5te" => "arm",
-                "armv7" => "arm",
-                "i586" | "i686" => {
-                    let zig_version = Zig::zig_version()?;
-                    if zig_version.major == 0 && zig_version.minor >= 11 {
-                        "x86"
-                    } else {
-                        "i386"
-                    }
-                }
-                "riscv64gc" => "riscv64",
-                "s390x" => "s390x",
-                _ => arch.as_str(),
-            };
-            let mut zig_target_env = target_env.to_string();
-
-            let zig_version = Zig::zig_version()?;
-
-            // Since Zig 0.15.0, arm-linux-ohos changed to arm-linux-ohoseabi
-            // We need to follow the change but target_lexicon follow the LLVM target(https://github.com/bytecodealliance/target-lexicon/pull/123).
-            // So we use string directly.
-            if zig_version >= semver::Version::new(0, 15, 0)
-                && arch.as_str() == "armv7"
-                && target_env == Environment::Ohos
-            {
-                zig_target_env = "ohoseabi".to_string();
-            }
-
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{zig_arch}-linux-{zig_target_env}{abi_suffix}"));
-        }
-        OperatingSystem::MacOSX { .. } | OperatingSystem::Darwin(_) => {
-            let zig_version = Zig::zig_version()?;
-            // Zig 0.10.0 switched macOS ABI to none
-            // see https://github.com/ziglang/zig/pull/11684
-            if zig_version > semver::Version::new(0, 9, 1) {
-                cc_args.push("-target".to_string());
-                cc_args.push(format!("{arch}-macos-none{abi_suffix}"));
-            } else {
-                cc_args.push("-target".to_string());
-                cc_args.push(format!("{arch}-macos-gnu{abi_suffix}"));
-            }
-        }
-        OperatingSystem::Windows => {
-            let zig_arch = match arch.as_str() {
-                "i686" => {
-                    let zig_version = Zig::zig_version()?;
-                    if zig_version.major == 0 && zig_version.minor >= 11 {
-                        "x86"
-                    } else {
-                        "i386"
-                    }
-                }
-                arch => arch,
-            };
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{zig_arch}-windows-{target_env}{abi_suffix}"));
-        }
-        OperatingSystem::Emscripten => {
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{arch}-emscripten{abi_suffix}"));
-        }
-        OperatingSystem::Wasi => {
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{arch}-wasi{abi_suffix}"));
-        }
-        OperatingSystem::WasiP1 => {
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{arch}-wasi.0.1.0{abi_suffix}"));
-        }
-        OperatingSystem::IOS(_) if triple.environment == Environment::Macabi => {
-            // Mac Catalyst (aarch64-apple-ios-macabi / x86_64-apple-ios-macabi)
-            // maps to zig's maccatalyst target
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{arch}-maccatalyst-none{abi_suffix}"));
-        }
-        OperatingSystem::Freebsd => {
-            let zig_arch = match arch.as_str() {
-                "i686" => {
-                    let zig_version = Zig::zig_version()?;
-                    if zig_version.major == 0 && zig_version.minor >= 11 {
-                        "x86"
-                    } else {
-                        "i386"
-                    }
-                }
-                arch => arch,
-            };
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{zig_arch}-freebsd"));
-        }
-        OperatingSystem::Openbsd => {
-            cc_args.push("-target".to_string());
-            cc_args.push(format!("{arch}-openbsd"));
-        }
-        OperatingSystem::Unknown => {
-            if triple.architecture == Architecture::Wasm32
-                || triple.architecture == Architecture::Wasm64
-            {
-                cc_args.push("-target".to_string());
-                cc_args.push(format!("{arch}-freestanding{abi_suffix}"));
-            } else {
-                bail!("unsupported target '{rust_target}'")
-            }
-        }
-        _ => bail!(format!("unsupported target '{rust_target}'")),
-    };
+    let zig_target = zig_target_triple(
+        rust_target,
+        &triple,
+        target_env,
+        &abi_suffix,
+        &Zig::zig_version()?,
+    )?;
+    cc_args.push("-target".to_string());
+    cc_args.push(zig_target.clone());
 
     let zig_linker_dir = cache_dir();
     fs::create_dir_all(&zig_linker_dir)?;
@@ -417,6 +309,7 @@ pub fn prepare_zig_linker_with_cli_config(
         ar: zig_ar,
         ranlib: zig_ranlib,
         lib: zig_lib,
+        target: zig_target,
     })
 }
 
@@ -636,6 +529,125 @@ pub fn adjust_canonicalization(p: String) -> String {
     }
 }
 
+/// Maps a Rust target's environment to the one zig names it by.
+fn zig_target_env(triple: &Triple) -> Environment {
+    match (triple.architecture, triple.environment) {
+        (Architecture::Mips32(..), Environment::Gnu) => Environment::Gnueabihf,
+        (Architecture::Mips32(..), Environment::Musl) => Environment::Musleabi,
+        (Architecture::Powerpc, Environment::Gnu) => Environment::Gnueabihf,
+        (_, Environment::GnuLlvm) => Environment::Gnu,
+        (_, environment) => environment,
+    }
+}
+
+/// Build the target triple to pass to `zig cc -target`, where `abi_suffix` is
+/// the glibc version including its leading dot (`.2.36`) or an empty string.
+fn zig_target_triple(
+    rust_target: &str,
+    triple: &Triple,
+    target_env: Environment,
+    abi_suffix: &str,
+    zig_version: &semver::Version,
+) -> Result<String> {
+    let arch = triple.architecture.to_string();
+    let zig_target = match triple.operating_system {
+        OperatingSystem::Linux => {
+            let zig_arch = match arch.as_str() {
+                // zig uses _ instead of - in cpu features
+                "arm" => "arm",
+                "armv5te" => "arm",
+                "armv7" => "arm",
+                "i586" | "i686" => {
+                    if zig_version.major == 0 && zig_version.minor >= 11 {
+                        "x86"
+                    } else {
+                        "i386"
+                    }
+                }
+                "riscv64gc" => "riscv64",
+                "s390x" => "s390x",
+                _ => arch.as_str(),
+            };
+            let mut zig_target_env = target_env.to_string();
+
+            // Since Zig 0.15.0, arm-linux-ohos changed to arm-linux-ohoseabi
+            // We need to follow the change but target_lexicon follow the LLVM target(https://github.com/bytecodealliance/target-lexicon/pull/123).
+            // So we use string directly.
+            if *zig_version >= semver::Version::new(0, 15, 0)
+                && arch.as_str() == "armv7"
+                && target_env == Environment::Ohos
+            {
+                zig_target_env = "ohoseabi".to_string();
+            }
+
+            format!("{zig_arch}-linux-{zig_target_env}{abi_suffix}")
+        }
+        OperatingSystem::MacOSX { .. } | OperatingSystem::Darwin(_) => {
+            // Zig 0.10.0 switched macOS ABI to none
+            // see https://github.com/ziglang/zig/pull/11684
+            if *zig_version > semver::Version::new(0, 9, 1) {
+                format!("{arch}-macos-none{abi_suffix}")
+            } else {
+                format!("{arch}-macos-gnu{abi_suffix}")
+            }
+        }
+        OperatingSystem::Windows => {
+            let zig_arch = match arch.as_str() {
+                "i686" => {
+                    if zig_version.major == 0 && zig_version.minor >= 11 {
+                        "x86"
+                    } else {
+                        "i386"
+                    }
+                }
+                arch => arch,
+            };
+            format!("{zig_arch}-windows-{target_env}{abi_suffix}")
+        }
+        OperatingSystem::Emscripten => {
+            format!("{arch}-emscripten{abi_suffix}")
+        }
+        OperatingSystem::Wasi => {
+            format!("{arch}-wasi{abi_suffix}")
+        }
+        OperatingSystem::WasiP1 => {
+            format!("{arch}-wasi.0.1.0{abi_suffix}")
+        }
+        OperatingSystem::IOS(_) if triple.environment == Environment::Macabi => {
+            // Mac Catalyst (aarch64-apple-ios-macabi / x86_64-apple-ios-macabi)
+            // maps to zig's maccatalyst target
+            format!("{arch}-maccatalyst-none{abi_suffix}")
+        }
+        OperatingSystem::Freebsd => {
+            let zig_arch = match arch.as_str() {
+                "i686" => {
+                    if zig_version.major == 0 && zig_version.minor >= 11 {
+                        "x86"
+                    } else {
+                        "i386"
+                    }
+                }
+                arch => arch,
+            };
+            format!("{zig_arch}-freebsd")
+        }
+        OperatingSystem::Openbsd => {
+            format!("{arch}-openbsd")
+        }
+        OperatingSystem::Unknown => {
+            if triple.architecture == Architecture::Wasm32
+                || triple.architecture == Architecture::Wasm64
+            {
+                format!("{arch}-freestanding{abi_suffix}")
+            } else {
+                bail!("unsupported target '{rust_target}'")
+            }
+        }
+        _ => bail!(format!("unsupported target '{rust_target}'")),
+    };
+    Ok(zig_target)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -732,5 +744,95 @@ mod tests {
         // Simple args should not be quoted
         assert!(result.contains("-target"));
         assert!(!result.contains("\"-target\""));
+    }
+
+    /// Mirrors the prologue of [`prepare_zig_linker_with_cli_config`].
+    fn zig_target(target: &str, zig_version: &str) -> Result<String> {
+        let (rust_target, abi_suffix) = target.split_once('.').unwrap_or((target, ""));
+        let abi_suffix = if abi_suffix.is_empty() {
+            String::new()
+        } else {
+            format!(".{abi_suffix}")
+        };
+        let triple: Triple = rust_target.parse()?;
+        let target_env = zig_target_env(&triple);
+        zig_target_triple(
+            rust_target,
+            &triple,
+            target_env,
+            &abi_suffix,
+            &semver::Version::parse(zig_version)?,
+        )
+    }
+
+    #[test]
+    fn test_zig_target_triple() {
+        let cases = [
+            // Rust target (with optional glibc suffix), zig version, zig target
+            ("x86_64-unknown-linux-gnu", "0.15.2", "x86_64-linux-gnu"),
+            (
+                "x86_64-unknown-linux-gnu.2.36",
+                "0.15.2",
+                "x86_64-linux-gnu.2.36",
+            ),
+            ("aarch64-unknown-linux-musl", "0.15.2", "aarch64-linux-musl"),
+            (
+                "armv7-unknown-linux-gnueabihf",
+                "0.15.2",
+                "arm-linux-gnueabihf",
+            ),
+            (
+                "arm-unknown-linux-gnueabihf",
+                "0.15.2",
+                "arm-linux-gnueabihf",
+            ),
+            ("riscv64gc-unknown-linux-gnu", "0.15.2", "riscv64-linux-gnu"),
+            ("s390x-unknown-linux-gnu", "0.15.2", "s390x-linux-gnu"),
+            // zig 0.11 renamed the 32-bit x86 arch from i386 to x86
+            ("i686-unknown-linux-gnu", "0.15.2", "x86-linux-gnu"),
+            ("i686-unknown-linux-gnu", "0.10.1", "i386-linux-gnu"),
+            // zig 0.15 renamed arm-linux-ohos to arm-linux-ohoseabi
+            ("armv7-unknown-linux-ohos", "0.15.2", "arm-linux-ohoseabi"),
+            ("armv7-unknown-linux-ohos", "0.14.1", "arm-linux-ohos"),
+            (
+                "powerpc-unknown-linux-gnu",
+                "0.15.2",
+                "powerpc-linux-gnueabihf",
+            ),
+            // zig 0.10 switched the macOS abi to none
+            ("aarch64-apple-darwin", "0.15.2", "aarch64-macos-none"),
+            ("aarch64-apple-darwin", "0.9.1", "aarch64-macos-gnu"),
+            (
+                "aarch64-apple-ios-macabi",
+                "0.15.2",
+                "aarch64-maccatalyst-none",
+            ),
+            ("x86_64-pc-windows-gnu", "0.15.2", "x86_64-windows-gnu"),
+            ("i686-pc-windows-gnu", "0.15.2", "x86-windows-gnu"),
+            ("i686-pc-windows-gnu", "0.10.1", "i386-windows-gnu"),
+            ("wasm32-wasip1", "0.15.2", "wasm32-wasi.0.1.0"),
+            ("wasm32-wasi", "0.15.2", "wasm32-wasi"),
+            ("wasm32-unknown-unknown", "0.15.2", "wasm32-freestanding"),
+            ("wasm32-unknown-emscripten", "0.15.2", "wasm32-emscripten"),
+            ("x86_64-unknown-freebsd", "0.15.2", "x86_64-freebsd"),
+            ("x86_64-unknown-openbsd", "0.15.2", "x86_64-openbsd"),
+        ];
+
+        for (target, zig_version, expected) in cases {
+            assert_eq!(
+                zig_target(target, zig_version).unwrap(),
+                expected,
+                "{target} with zig {zig_version}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_zig_target_triple_unsupported() {
+        let err = zig_target("x86_64-unknown-redox", "0.15.2").unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported target"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
Closes #473

`cargo zigbuild --target x86_64-unknown-linux-gnu.2.36` resolves a zig target
triple, pushes it into the wrapper as `-target`, and drops the string. A build
script that drives a native build of its own, rather than compiling C through
`cc`, cannot recover it: cargo's `TARGET` has the glibc version stripped, and
`CC_<target>` only helps if you go through `cc`. #473 has the measurement.

`ZigWrapper` now keeps that triple and `apply_command_env` exports it.

`CARGO_ZIGBUILD_TARGET_<target>` is always set, following the `CC_<target>`
convention. The unsuffixed `CARGO_ZIGBUILD_TARGET` is set only for a single
`--target`, since one variable cannot answer for several of them. Both are set
unconditionally rather than through `add_env_if_missing`: that exists so a user
can override an input, but this is an output, and a value inherited from an
outer `cargo zigbuild` is stale rather than an override — inherited ones are
dropped before this build's are exported, which the unsuffixed name needs
since a multi-target build sets no value of its own.

Most of the diff is the OS match moving out of
`prepare_zig_linker_with_cli_config` into `zig_target_triple` unchanged, which
is what lets the added test cover 24 target/zig-version pairs without a zig
installation. One side effect: the zig version is now looked up before the
`bail!` for an unsupported target, so with no zig on PATH that error changes.

Checked end-to-end with zig 0.16.0 that a build script sees
`x86_64-linux-gnu.2.36`, and that with two `--target`s each build script sees
only its own suffixed variable.
