### PR TITLE
fix: pass a `-Wl,<path>` input file to zig cc as a positional argument

### DIFF
--- a/src/zig/linker_args.rs
+++ b/src/zig/linker_args.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::target_info::TargetInfo;
 
 pub(crate) enum FilteredArg {
@@ -108,6 +110,23 @@ pub(crate) fn filter_linker_arg(
         || arg.starts_with("-Wl,-plugin-opt")
     {
         return FilteredArg::Skip;
+    }
+
+    // An input file that reached us through `-Wl,`.
+    //
+    // rustc passes a native static library bundled in an rlib as
+    // `-Wl,--whole-archive -Wl,<path> -Wl,--no-whole-archive`, which is what a build
+    // script asking for `link_lib_modifier("+whole-archive")` produces. cc and clang
+    // forward a `-Wl,` value that is not an option to the linker as a positional
+    // input; zig cc matches every `-Wl,` value against a list of linker flags it
+    // knows and fails with `unsupported linker arg: <path>` instead. Passing it
+    // positionally is the same thing the other drivers do, and leaves the
+    // `--whole-archive` pair around it untouched.
+    if let Some(path) = arg
+        .strip_prefix("-Wl,")
+        .filter(|path| !path.starts_with('-') && Path::new(path).is_file())
+    {
+        return FilteredArg::Keep(vec![path.to_owned()]);
     }
     if target_info.is_musl() || target_info.is_ohos() {
         if (arg.ends_with(".o") && arg.contains("self-contained") && arg.contains("crt"))
@@ -783,5 +802,43 @@ mod tests {
             (13, 0),
         );
         assert_eq!(result, vec!["-o", "output"]);
+    }
+
+    #[test]
+    fn test_filter_wl_path_becomes_positional() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("libtree-sitter-bash.a");
+        std::fs::write(&archive, b"").unwrap();
+        let archive = archive.to_str().unwrap();
+
+        // How rustc passes a static library bundled in an rlib with `+whole-archive`.
+        let result = run_filter(
+            &[
+                "-Wl,--whole-archive",
+                &format!("-Wl,{archive}"),
+                "-Wl,--no-whole-archive",
+            ],
+            Some("x86_64-unknown-linux-musl"),
+            (13, 0),
+        );
+        assert_eq!(
+            result,
+            vec!["-Wl,--whole-archive", archive, "-Wl,--no-whole-archive"]
+        );
+    }
+
+    #[test]
+    fn test_filter_leaves_other_wl_args_alone() {
+        let linux = Some("x86_64-unknown-linux-gnu");
+        // An option, not an input file.
+        assert_eq!(
+            run_filter_one("-Wl,-rpath,/usr/lib", linux, (13, 0)),
+            vec!["-Wl,-rpath,/usr/lib"]
+        );
+        // A path that is not there is not an input file either.
+        assert_eq!(
+            run_filter_one("-Wl,/no/such/libfoo.a", linux, (13, 0)),
+            vec!["-Wl,/no/such/libfoo.a"]
+        );
     }
 }


### PR DESCRIPTION
## The problem

rustc passes a native static library bundled in an rlib as

```
-Wl,--whole-archive -Wl,<path> -Wl,--no-whole-archive
```

which is what a build script calling `cc::Build::link_lib_modifier("+whole-archive")` produces.

`cc` and `clang` forward a `-Wl,` value that is not an option to the linker as a positional input. `zig cc` instead matches every `-Wl,` value against the linker flags it knows, so the path is rejected:

```
error: unsupported linker arg: /…/target/x86_64-unknown-linux-musl/release/deps/rustcqxGk6h/libtree-sitter-bash.a
```

The result is that no crate whose build script asks for `+whole-archive` can be cross-linked with `cargo zigbuild`. I hit it on [`lumis`](https://crates.io/crates/lumis), which compiles around twenty vendored tree-sitter grammars that way; the link fails on the first archive and there are nineteen behind it.

## The change

`filter_linker_arg` rewrites `-Wl,<path>` to the bare `<path>` when the value is not an option and names a file that exists, which is what the other drivers hand the linker. The `--whole-archive` / `--no-whole-archive` pair around it is untouched, and so is everything else arriving through `-Wl,`: a value beginning with `-` is an option, and a path that is not there would not have linked either way.

It sits after the `windows_gnu` branch, so the existing `list.def` skip still takes precedence there.

## Verification

Two unit tests: the `--whole-archive` triple rustc emits, and the two `-Wl,` forms that must be left alone.

End to end, cross-compiling an application that depends on `lumis` from an aarch64 macOS host to `x86_64-unknown-linux-musl` — the build that failed on `libtree-sitter-bash.a` now links:

```
Finished `release` profile [optimized] target(s) in 5m 03s
$ file target/x86_64-unknown-linux-musl/release/ivashkin
ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```

`cargo test`, `cargo clippy --all-targets --all-features` and `cargo fmt --all` are clean. No extra tooling is needed to run the new tests — `tempfile` is already a dev-dependency.
