### PR TITLE
fix: preserve linker list operands with Zig 0.16

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           brew install mingw-w64
       - run: cargo build
+      - run: cargo test --all-targets --all-features
       - name: Install Rust targets
         shell: bash
         run: |

--- a/src/zig/linker_args.rs
+++ b/src/zig/linker_args.rs
@@ -4,35 +4,70 @@ use super::target_info::TargetInfo;
 
 pub(crate) enum FilteredArg {
     Keep(Vec<String>),
+    /// Keep this option and its following operand without filtering the operand.
+    KeepWithNext,
     Skip,
     SkipWithNext,
 }
 
-pub(crate) fn filter_linker_args(
-    args: impl IntoIterator<Item = String>,
-    rustc_ver: &rustc_version::Version,
-    zig_version: &semver::Version,
-    target_info: &TargetInfo,
-) -> Vec<String> {
-    let mut result = Vec::new();
-    let mut skip_next = false;
-    for arg in args {
-        if skip_next {
-            skip_next = false;
-            continue;
+/// Keep option/operand handling consistent across command-line and response-file args.
+#[derive(Default)]
+pub(crate) struct LinkerArgFilter {
+    next: NextArg,
+}
+
+#[derive(Default)]
+enum NextArg {
+    #[default]
+    Filter,
+    Keep,
+    Skip,
+}
+
+impl LinkerArgFilter {
+    pub(crate) fn filter_arg(
+        &mut self,
+        arg: &str,
+        rustc_ver: &rustc_version::Version,
+        zig_version: &semver::Version,
+        target_info: &TargetInfo,
+    ) -> Vec<String> {
+        match std::mem::take(&mut self.next) {
+            NextArg::Keep => return vec![arg.to_owned()],
+            NextArg::Skip => return vec![],
+            NextArg::Filter => {}
         }
-        match filter_linker_arg(&arg, rustc_ver, zig_version, target_info) {
-            FilteredArg::Keep(filtered) => result.extend(filtered),
-            FilteredArg::Skip => {}
+        match filter_linker_arg(arg, rustc_ver, zig_version, target_info) {
+            FilteredArg::Keep(filtered) => filtered,
+            FilteredArg::KeepWithNext => {
+                self.next = NextArg::Keep;
+                vec![arg.to_owned()]
+            }
+            FilteredArg::Skip => vec![],
             FilteredArg::SkipWithNext => {
-                skip_next = true;
+                self.next = NextArg::Skip;
+                vec![]
             }
         }
     }
-    if target_info.is_apple_platform() {
-        result = dedup_apple_link_libs(result);
+
+    pub(crate) fn filter_args(
+        &mut self,
+        args: impl IntoIterator<Item = String>,
+        rustc_ver: &rustc_version::Version,
+        zig_version: &semver::Version,
+        target_info: &TargetInfo,
+    ) -> Vec<String> {
+        let result = args
+            .into_iter()
+            .flat_map(|arg| self.filter_arg(&arg, rustc_ver, zig_version, target_info))
+            .collect();
+        if target_info.is_apple_platform() {
+            dedup_apple_link_libs(result)
+        } else {
+            result
+        }
     }
-    result
 }
 
 /// Deduplicate `-l` arguments for Apple targets, keeping the first occurrence.
@@ -217,6 +252,10 @@ pub(crate) fn filter_linker_arg(
         {
             return FilteredArg::Skip;
         }
+    } else if arg == "-Wl,-exported_symbols_list" || arg == "-Wl,--dynamic-list" {
+        // These files are operands, not positional linker inputs. In particular,
+        // do not apply the `-Wl,<path>` rewrite to an existing symbols list (#479).
+        return FilteredArg::KeepWithNext;
     }
     if target_info.is_freebsd() {
         let ignored_libs = ["-lkvm", "-lmemstat", "-lprocstat", "-ldevstat"];
@@ -320,7 +359,7 @@ mod tests {
         let rustc_ver = make_rustc_ver(1, 80, 0);
         let zig_version = make_zig_ver(0, zig_ver.0, zig_ver.1);
         let target_info = TargetInfo::new(target.map(|s| s.to_string()).as_ref());
-        filter_linker_args(
+        LinkerArgFilter::default().filter_args(
             args.iter().map(|s| s.to_string()),
             &rustc_ver,
             &zig_version,
@@ -341,7 +380,7 @@ mod tests {
         let rustc_ver = make_rustc_ver(1, rustc_minor, 0);
         let zig_version = make_zig_ver(0, zig_ver.0, zig_ver.1);
         let target_info = TargetInfo::new(target.map(|s| s.to_string()).as_ref());
-        filter_linker_args(
+        LinkerArgFilter::default().filter_args(
             std::iter::once(arg.to_string()),
             &rustc_ver,
             &zig_version,
@@ -735,10 +774,14 @@ mod tests {
 
     #[test]
     fn test_filter_exported_symbols_list_not_filtered_zig_016() {
+        let dir = tempfile::tempdir().unwrap();
+        let list = dir.path().join("list");
+        std::fs::write(&list, "_hello\n").unwrap();
+        let list_arg = format!("-Wl,{}", list.display());
         let result = run_filter(
             &[
                 "-Wl,-exported_symbols_list",
-                "-Wl,/tmp/rustcXXX/list",
+                &list_arg,
                 "-o",
                 "output.dylib",
             ],
@@ -749,7 +792,7 @@ mod tests {
             result,
             vec![
                 "-Wl,-exported_symbols_list",
-                "-Wl,/tmp/rustcXXX/list",
+                &list_arg,
                 "-o",
                 "output.dylib"
             ]

--- a/src/zig/mod.rs
+++ b/src/zig/mod.rs
@@ -13,7 +13,7 @@ use fs_err as fs;
 use target_lexicon::Architecture;
 
 use cargo_env::{write_file, write_tbd_files};
-use linker_args::{FilteredArg, dedup_apple_link_libs, filter_linker_arg, filter_linker_args};
+use linker_args::{LinkerArgFilter, dedup_apple_link_libs};
 use locate::cache_dir;
 use target_info::TargetInfo;
 
@@ -135,6 +135,7 @@ impl Zig {
 
         let mut new_cmd_args = Vec::with_capacity(cmd_args.len());
         let mut skip_next_arg = false;
+        let mut linker_filter = LinkerArgFilter::default();
         let mut seen_target = false;
         for arg in cmd_args {
             if skip_next_arg {
@@ -157,16 +158,10 @@ impl Zig {
                     &rustc_ver,
                     &zig_version,
                     &target_info,
+                    &mut linker_filter,
                 )?]
             } else {
-                match self.filter_linker_arg(arg, &rustc_ver, &zig_version, &target_info) {
-                    FilteredArg::Keep(filtered) => filtered,
-                    FilteredArg::Skip => continue,
-                    FilteredArg::SkipWithNext => {
-                        skip_next_arg = true;
-                        continue;
-                    }
-                }
+                linker_filter.filter_arg(arg, &rustc_ver, &zig_version, &target_info)
             };
             new_cmd_args.extend(args);
         }
@@ -232,6 +227,7 @@ impl Zig {
         rustc_ver: &rustc_version::Version,
         zig_version: &semver::Version,
         target_info: &TargetInfo,
+        linker_filter: &mut LinkerArgFilter,
     ) -> Result<String> {
         // rustc passes arguments to linker via an @-file when arguments are too long
         // See https://github.com/rust-lang/rust/issues/41190
@@ -262,8 +258,9 @@ impl Zig {
                 )
             })?
         };
-        let mut link_args: Vec<_> = filter_linker_args(
-            content.split('\n').map(|s| s.to_string()),
+        let mut link_args = linker_filter.filter_args(
+            // A final newline must not consume an operand expected after this file.
+            content.split_terminator('\n').map(|s| s.to_string()),
             rustc_ver,
             zig_version,
             target_info,
@@ -288,16 +285,6 @@ impl Zig {
             fs::write(arg.trim_start_matches('@'), link_args.join("\n").as_bytes())?;
         }
         Ok(arg.to_string())
-    }
-
-    fn filter_linker_arg(
-        &self,
-        arg: &str,
-        rustc_ver: &rustc_version::Version,
-        zig_version: &semver::Version,
-        target_info: &TargetInfo,
-    ) -> FilteredArg {
-        filter_linker_arg(arg, rustc_ver, zig_version, target_info)
     }
 
     fn has_undefined_dynamic_lookup(&self, args: &[String]) -> bool {

--- a/src/zig/wrapper.rs
+++ b/src/zig/wrapper.rs
@@ -363,7 +363,7 @@ where
 /// - `%` expands even inside quotes, so we escape it as `%%`.
 /// - We disable delayed expansion in the wrapper script, so `!` should not expand.
 /// - Internal `"` are escaped by doubling them (`""`).
-#[cfg(not(target_family = "unix"))]
+#[cfg(any(not(target_family = "unix"), test))]
 fn quote_for_batch(s: &str) -> String {
     let needs_quoting_or_escaping = s.is_empty()
         || s.contains(|c: char| {
@@ -701,7 +701,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_family = "unix"))]
     fn test_quote_for_batch() {
         // Simple argument without special characters - no quoting needed
         assert_eq!(quote_for_batch("-target"), "-target");
@@ -722,7 +721,11 @@ mod tests {
         assert_eq!(quote_for_batch("foo<bar"), "\"foo<bar\"");
         assert_eq!(quote_for_batch("foo>bar"), "\"foo>bar\"");
         assert_eq!(quote_for_batch("foo^bar"), "\"foo^bar\"");
-        assert_eq!(quote_for_batch("foo%bar"), "\"foo%bar\"");
+
+        // Percent signs must be doubled even inside quotes in a batch file.
+        assert_eq!(quote_for_batch("foo%bar"), "\"foo%%bar\"");
+        assert_eq!(quote_for_batch("%PATH%"), "\"%%PATH%%\"");
+        assert_eq!(quote_for_batch("%1"), "\"%%1\"");
 
         // Internal double quotes are escaped by doubling
         assert_eq!(quote_for_batch("foo\"bar"), "\"foo\"\"bar\"");

--- a/tests/linker_args.rs
+++ b/tests/linker_args.rs
@@ -1,0 +1,217 @@
+//! Exercise both production argument paths without requiring an installed Zig.
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+fn filter_args(
+    args: &[String],
+    zig_version: &str,
+    response_range: Option<std::ops::Range<usize>>,
+    target: &str,
+) -> Vec<String> {
+    let dir = tempfile::tempdir().unwrap();
+    let zig = dir.path().join("zig");
+    let captured = dir.path().join("captured");
+    std::fs::write(
+        &zig,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$CAPTURED_ARGS\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&zig, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let response = dir.path().join("linker-arguments");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_cargo-zigbuild"));
+    command.args(["zig", "cc", "--", "-target", target]);
+    if let Some(ref range) = response_range {
+        command.args(&args[..range.start]);
+        let content = format!("{}\n", args[range.clone()].join("\n"));
+        let bytes = if target.ends_with("windows-msvc") {
+            std::iter::once(0xFEFF)
+                .chain(content.encode_utf16())
+                .flat_map(u16::to_le_bytes)
+                .collect()
+        } else {
+            content.into_bytes()
+        };
+        std::fs::write(&response, bytes).unwrap();
+        command.arg(format!("@{}", response.display()));
+        command.args(&args[range.end..]);
+    } else {
+        command.args(args);
+    }
+    let output = command
+        .env("CARGO_ZIGBUILD_ZIG_COMMAND", &zig)
+        .env("CARGO_ZIGBUILD_ZIG_COMMAND_ARGS", "")
+        .env("CARGO_ZIGBUILD_ZIG_VERSION", zig_version)
+        .env("CARGO_ZIGBUILD_RUSTC_VERSION", "1.96.0")
+        .env("CAPTURED_ARGS", &captured)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response_args: Vec<String> = if response_range.is_some() {
+        let bytes = std::fs::read(&response).unwrap();
+        let content = if target.ends_with("windows-msvc") {
+            assert_eq!(&bytes[..2], &[255, 254]);
+            let utf16: Vec<_> = bytes[2..]
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|c| u16::from_le_bytes(*c))
+                .collect();
+            String::from_utf16(&utf16).unwrap()
+        } else {
+            String::from_utf8(bytes).unwrap()
+        };
+        content.lines().map(str::to_owned).collect()
+    } else {
+        vec![]
+    };
+    // Expand the response file exactly where Zig would receive it.
+    std::fs::read_to_string(captured)
+        .unwrap()
+        .lines()
+        .skip(3) // `cc -target <target>` supplied by this helper
+        .flat_map(|arg| {
+            if arg == format!("@{}", response.display()) {
+                response_args.clone()
+            } else {
+                vec![arg.to_owned()]
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn list_operands_and_whole_archive_in_both_argument_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let list = dir.path().join("export list");
+    let archive = dir.path().join("libnative.a");
+    std::fs::write(&list, "_hello\n").unwrap();
+    std::fs::write(&archive, "").unwrap();
+    for response_file in [false, true] {
+        for (version, keep_list) in [
+            ("0.11.0", false),
+            ("0.15.2", false),
+            ("0.16.0", true),
+            ("0.17.0", true),
+        ] {
+            for flag in ["-exported_symbols_list", "--dynamic-list"] {
+                for combined in [false, true] {
+                    let mut args = if combined {
+                        vec![format!("-Wl,{flag},{}", list.display())]
+                    } else {
+                        vec![format!("-Wl,{flag}"), format!("-Wl,{}", list.display())]
+                    };
+                    let mut expected = if keep_list { args.clone() } else { vec![] };
+                    args.extend([
+                        "-Wl,--whole-archive".to_owned(),
+                        format!("-Wl,{}", archive.display()),
+                        "-Wl,--no-whole-archive".to_owned(),
+                        "-Wl,-dead_strip".to_owned(),
+                    ]);
+                    expected.extend([
+                        "-Wl,--whole-archive".to_owned(),
+                        archive.display().to_string(),
+                        "-Wl,--no-whole-archive".to_owned(),
+                        "-Wl,-dead_strip".to_owned(),
+                    ]);
+                    for target in [
+                        "aarch64-apple-darwin",
+                        "x86_64-unknown-linux-gnu",
+                        "x86_64-pc-windows-msvc",
+                    ] {
+                        assert_eq!(
+                            filter_args(
+                                &args,
+                                version,
+                                response_file.then_some(0..args.len()),
+                                target
+                            ),
+                            expected,
+                            "version={version}, flag={flag}, combined={combined}, response_file={response_file}, target={target}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn list_operand_preservation_ends_after_one_argument() {
+    let dir = tempfile::tempdir().unwrap();
+    let list = dir.path().join("list");
+    std::fs::write(&list, "_hello\n").unwrap();
+    for response_file in [false, true] {
+        for operand in [
+            vec![list.display().to_string()],
+            vec!["-Xlinker".to_owned(), list.display().to_string()],
+        ] {
+            let mut args = vec!["-Wl,-exported_symbols_list".to_owned()];
+            args.extend(operand);
+            let mut expected = args.clone();
+            args.extend([
+                "--target=ignored".to_owned(),
+                "-lgcc_s".to_owned(),
+                "-lSystem".to_owned(),
+                "-lSystem".to_owned(),
+            ]);
+            expected.extend(["-lunwind".to_owned(), "-lSystem".to_owned()]);
+            assert_eq!(
+                filter_args(
+                    &args,
+                    "0.16.0",
+                    response_file.then_some(0..args.len()),
+                    "aarch64-apple-darwin"
+                ),
+                expected
+            );
+        }
+        // A missing operand must not panic or invent a filename.
+        let args = vec!["-Wl,-exported_symbols_list".to_owned()];
+        assert_eq!(
+            filter_args(
+                &args,
+                "0.16.0",
+                response_file.then_some(0..args.len()),
+                "aarch64-apple-darwin"
+            ),
+            args
+        );
+    }
+}
+
+#[test]
+fn list_pair_crosses_response_file_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let list = dir.path().join("list");
+    let archive = dir.path().join("libnative.a");
+    std::fs::write(&list, "_hello\n").unwrap();
+    std::fs::write(&archive, "").unwrap();
+    let args = vec![
+        "-Wl,-exported_symbols_list".to_owned(),
+        format!("-Wl,{}", list.display()),
+        "-Wl,--whole-archive".to_owned(),
+        format!("-Wl,{}", archive.display()),
+        "-Wl,--no-whole-archive".to_owned(),
+    ];
+    for range in [0..1, 1..args.len()] {
+        for (version, keep_list) in [("0.15.2", false), ("0.16.0", true)] {
+            let mut expected = args.clone();
+            expected[3] = archive.display().to_string();
+            if !keep_list {
+                expected.drain(..2);
+            }
+            assert_eq!(
+                filter_args(&args, version, Some(range.clone()), "aarch64-apple-darwin"),
+                expected,
+                "version={version}, range={range:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Since 0.23.4, an existing filename passed as `-Wl,<path>` is rewritten as a positional input even when it is the operand of `-exported_symbols_list`. With Zig 0.16, an Apple cdylib link then fails with `unable to read exported symbols list '-dead_strip': FileNotFound`.

Preserve the following operand for the two list options already handled by the filter: `-exported_symbols_list` and `--dynamic-list`. Share filtering state between command-line arguments and response files, including pairs that cross a response-file boundary. A trailing response-file newline no longer consumes a pending operand. Older Zig versions still strip these list pairs, and the positional archive rewrite from #477 is preserved.

Replace the nonexistent filename in the existing Zig 0.16 unit test with a real file. Add executable-wrapper regression tests covering 106 argument scenarios: split and combined forms, old and new version gates, whole-archive inputs, subsequent argument filtering, UTF-16 response files, and pairs crossing response-file boundaries. Run the Rust test suite in the existing CI matrix. Correct the stale percent-escaping assertion exposed by running the suite on Windows, and run that pure string test on all hosts.

Validation on macOS with rustc 1.98.0:

- `cargo test --locked --all-targets --all-features`: 57 tests passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- `cargo clippy --locked --all-targets --all-features`: completed with five pre-existing warnings; strict `-D warnings` remains blocked by those warnings.
- A minimal Rust cdylib links, loads, and returns the expected value with Zig 0.16.0.
- Real Apple C links through direct, response-file, and split-boundary arguments match direct Zig's exported symbols.
- Real Linux ELF links with Zig 0.11.0 and 0.16.0 retain an otherwise unused archive symbol only when whole-archive is enabled, through both argument paths.

The executable-wrapper tests require Unix. They exercise Windows-target filtering and UTF-16 response files, but native Windows execution was not validated locally.

Fixes #479.
