### PR TITLE
fix: skip ARM unaligned shim during dependency generation

### DIFF
--- a/src/zig/mod.rs
+++ b/src/zig/mod.rs
@@ -177,8 +177,13 @@ impl Zig {
 
         // Rust's libstd for strict-align arm targets calls the ARM RTABI
         // unaligned-access helpers (__aeabi_uread4 etc.), which libgcc
-        // provides but zig's compiler-rt does not; link weak definitions
-        if target_info.is_arm() && !cmd_args.iter().any(|x| x == "-c" || x == "-E" || x == "-S") {
+        // provides but zig's compiler-rt does not; link weak definitions.
+        // -M/-MM only generate dependencies, whereas -MD/-MMD can still link.
+        if target_info.is_arm()
+            && !cmd_args
+                .iter()
+                .any(|x| matches!(x.as_str(), "-c" | "-E" | "-S" | "-M" | "-MM"))
+        {
             let cache_dir = cache_dir();
             fs::create_dir_all(&cache_dir)?;
             let shim_path = cache_dir.join("aeabi_unaligned.c");

--- a/tests/linker_args.rs
+++ b/tests/linker_args.rs
@@ -87,6 +87,42 @@ fn filter_args(
 }
 
 #[test]
+fn arm_dependency_generation_does_not_add_unaligned_shim() {
+    for mode in ["-M", "-MM", "-c", "-E", "-S"] {
+        let args: Vec<String> = [mode, "-MT", "jemalloc.o", "-o", "jemalloc.d", "jemalloc.c"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        assert_eq!(
+            filter_args(&args, "0.15.2", None, "arm-linux-gnueabihf"),
+            args,
+            "mode={mode}"
+        );
+    }
+}
+
+#[test]
+fn arm_linking_still_adds_unaligned_shim_with_dependency_side_effects() {
+    // Unlike -M/-MM, -MD/-MMD do not stop compilation and linking.
+    for mode in [None, Some("-MD"), Some("-MMD")] {
+        let args: Vec<String> = mode
+            .into_iter()
+            .chain(["-o", "hello", "hello.c"])
+            .map(str::to_owned)
+            .collect();
+        let filtered = filter_args(&args, "0.15.2", None, "arm-linux-gnueabihf");
+        assert_eq!(&filtered[..args.len()], &args);
+        assert_eq!(filtered.len(), args.len() + 1);
+        assert_eq!(
+            std::path::Path::new(filtered.last().unwrap())
+                .file_name()
+                .unwrap(),
+            "aeabi_unaligned.c"
+        );
+    }
+}
+
+#[test]
 fn list_operands_and_whole_archive_in_both_argument_paths() {
     let dir = tempfile::tempdir().unwrap();
     let list = dir.path().join("export list");


### PR DESCRIPTION
ARM compiler invocations using `-M` or `-MM`, such as Jemalloc's Makefile dependency generation, were treated as linking commands and received an extra `aeabi_unaligned.c` input. With a single `-o` output, Zig rejected the resulting command with `cannot specify -o when generating multiple output files`.

Skip the shim for both dependency-only modes. Keep injecting it for linking, including `-MD`/`-MMD`, which generate dependencies as a side effect. Regression tests exercise the CLI argument path and cover both behaviors plus the existing `-c`/`-E`/`-S` exclusions.

Validation:
- `cargo test`: 59 tests passed; the new dependency-generation test failed before the fix.
- Real Zig 0.16.0 ARM `-M` and `-MM` invocations with the reported CPU flag successfully generated dependency files after the fix.
- `cargo fmt --all --check` and `git diff --check`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: blocked by five pre-existing warnings in unchanged code (`useless_conversion`, `useless_borrows_in_formatting`, and `chunks_exact_to_as_chunks`).

Fixes #478.
